### PR TITLE
[CREATE] JPA 엔티티 및 MySQL 연동 완료

### DIFF
--- a/src/main/java/com/header/header/config/BeanConfig.java
+++ b/src/main/java/com/header/header/config/BeanConfig.java
@@ -1,0 +1,20 @@
+package com.header.header.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfig {
+
+    @Bean
+    public ModelMapper modelMapper(){
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration()
+                .setFieldAccessLevel(
+                        org.modelmapper.config.Configuration.AccessLevel.PRIVATE
+                )
+                .setFieldMatchingEnabled(true);
+        return modelMapper;
+    }
+}

--- a/src/main/java/com/header/header/domain/menu/entity/Menu.java
+++ b/src/main/java/com/header/header/domain/menu/entity/Menu.java
@@ -1,0 +1,25 @@
+package com.header.header.domain.menu.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tbl_menu")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int menuCode;
+    private Integer shopCode;
+    private Integer categoryCode;
+    private String menuName;
+    private int menuPrice;
+    private int estTime;
+    private Boolean isActive;
+
+
+}

--- a/src/main/java/com/header/header/domain/menu/entity/MenuCategory.java
+++ b/src/main/java/com/header/header/domain/menu/entity/MenuCategory.java
@@ -1,0 +1,22 @@
+package com.header.header.domain.menu.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tbl_menu_category")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class MenuCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int categoryCode;
+    private Integer shopCode;
+    private String categoryName;
+    private String menuColor;
+    private Boolean isActive;
+
+}

--- a/src/main/java/com/header/header/domain/message/enitity/MessageTemplate.java
+++ b/src/main/java/com/header/header/domain/message/enitity/MessageTemplate.java
@@ -1,0 +1,20 @@
+package com.header.header.domain.message.enitity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tbl_message_template")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class MessageTemplate {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY)
+    private int templeteCode;
+    private Integer shopCode;
+    private String templateContent;
+    private String templateType;
+}

--- a/src/main/java/com/header/header/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/header/header/domain/reservation/entity/Reservation.java
@@ -1,0 +1,30 @@
+package com.header.header.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+import java.sql.Date;
+import java.sql.Time;
+
+@Entity
+@Table(name="tbl_reservation")
+@Immutable  // Hibernate에게 읽기 전용임을 명시
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class Reservation {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY)
+    private int resvCode;
+    private Integer userCode;
+    private Integer shopCode;
+    private Integer menuCode;
+    private Date resvDate;
+    private Time resvTime;
+    private String userComment;
+    private String resvState;
+
+}

--- a/src/main/java/com/header/header/domain/sales/entity/Sales.java
+++ b/src/main/java/com/header/header/domain/sales/entity/Sales.java
@@ -1,0 +1,4 @@
+package com.header.header.domain.sales.entity;
+
+public class Sales {
+}

--- a/src/main/java/com/header/header/domain/sales/entity/Sales.java
+++ b/src/main/java/com/header/header/domain/sales/entity/Sales.java
@@ -1,4 +1,26 @@
 package com.header.header.domain.sales.entity;
 
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Time;
+
+@Entity
+@Table(name="tbl_sales")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
 public class Sales {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY)
+    private int salesCode;
+    private Integer resvCode;
+    private int payAmount;
+    private String payMethod;
+    private Time payDatetime;
+    private String payStatus;
+
 }

--- a/src/main/java/com/header/header/domain/shop/enitity/Shop.java
+++ b/src/main/java/com/header/header/domain/shop/enitity/Shop.java
@@ -1,0 +1,30 @@
+package com.header.header.domain.shop.enitity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tbl_shop")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class Shop {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int shopCode;
+    private Integer categoryCode;
+    private Integer adminCode;
+    private String shopName;
+    private String shopPhone;
+    private String shopLocation;
+    private Double shopLong;
+    private Double shopLa;
+    private String shopStatus;
+    private String shopOpen;
+    private String shopClose;
+    private Boolean isActive;
+
+
+}

--- a/src/main/java/com/header/header/domain/shop/enitity/ShopCategory.java
+++ b/src/main/java/com/header/header/domain/shop/enitity/ShopCategory.java
@@ -1,0 +1,21 @@
+package com.header.header.domain.shop.enitity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Table(name="tbl_shop_category")
+@Immutable  // Hibernate에게 읽기 전용임을 명시
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class ShopCategory {
+
+    @Id
+    private int categoryCode;
+    private String categoryName;
+}

--- a/src/main/java/com/header/header/domain/shop/enitity/ShopMessageHistory.java
+++ b/src/main/java/com/header/header/domain/shop/enitity/ShopMessageHistory.java
@@ -1,0 +1,28 @@
+package com.header.header.domain.shop.enitity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+import java.sql.Time;
+
+@Entity
+@Table(name="tbl_shop_msg_history")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class ShopMessageHistory {
+
+    @Id
+    private int smhCode;
+    private Integer userCode;
+    private Integer shopCode;
+    private Date date;
+    private Time time;
+    private String msgContent;
+    private String msgType;
+
+}

--- a/src/main/java/com/header/header/domain/user/enitity/User.java
+++ b/src/main/java/com/header/header/domain/user/enitity/User.java
@@ -1,0 +1,25 @@
+package com.header.header.domain.user.enitity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Table(name="tbl_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userCode;
+    private String userId;
+    private String userPwd;
+    private boolean isAdmin;
+    private String userName;
+    private String userPhone;
+    private Date birthday;
+    private boolean isLeave;
+}

--- a/src/main/java/com/header/header/domain/visitors/enitity/Visitors.java
+++ b/src/main/java/com/header/header/domain/visitors/enitity/Visitors.java
@@ -1,0 +1,23 @@
+package com.header.header.domain.visitors.enitity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="tbl_visitors")
+@Getter
+@NoArgsConstructor( access = AccessLevel.PROTECTED)
+public class Visitors {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY)
+    private int clientCode;
+    private Integer userCode;
+    private Integer shopCode;
+    private String memo;
+    private boolean sendable;
+    private boolean isActive;
+
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

1. PK가 Auto Increment 일 경우  @GeneratedValue 추가
``` java
@Id
@GeneratedValue(strategy = GenerationType.IDENTITY)
private int menuCode;
```

2. ShopCategory 엔티티는 `CREAT`, `UPDATE`, `DELETE` 기능이 필요 없기 때문에, 어노테이션으로 ==읽기 전용==임을 나타냄
``` java
@Entity
@Table(name="tbl_shop_category")
@Immutable  // Hibernate에게 읽기 전용임을 명시
@Getter
@NoArgsConstructor( access = AccessLevel.PROTECTED)
public class ShopCategory { /*생략*/
```
 