### PR TITLE
[Hotfix] #35 중복 체크 상세 적용

### DIFF
--- a/src/main/java/com/header/header/domain/auth/common/ApiResponse.java
+++ b/src/main/java/com/header/header/domain/auth/common/ApiResponse.java
@@ -14,9 +14,9 @@ public enum ApiResponse {
     DUPLICATE_PHONE("이미 존재하는 전화번호입니다.", HttpStatus.CONFLICT),
     DUPLICATE_ID("이미 존재하는 아이디입니다.", HttpStatus.CONFLICT),
 
-    SAME_PASSWORD("이전 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
-    SAME_PHONE("이전 전화번호와 동일합니다.", HttpStatus.BAD_REQUEST),
-    SAME_NAME("이전 이름과 동일합니다.", HttpStatus.BAD_REQUEST);
+    SAME_PASSWORD("(은)는 이전 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
+    SAME_PHONE("(은)는 이전 전화번호와 동일합니다.", HttpStatus.BAD_REQUEST),
+    SAME_NAME("(은)는 이전 이름과 동일합니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

중복 체크 메세지 상세 적용
 
## 🛠리팩토링

* registerNewUser()와 modifyUser() 메서드를 ApiResponse의 성공 메시지를 반환하도록 수정
* 해당 메소드를 사용한 Tests 코드도 함께 리팩토링

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f5bebb87-f592-49ff-9d42-fddea9d0a91d)
