### PR TITLE
[FIX] #53 Shop CRUD 기능 구현 완료

### DIFF
--- a/src/main/java/com/header/header/domain/shop/dto/MapServiceDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/MapServiceDTO.java
@@ -18,9 +18,9 @@ public class MapServiceDTO {
     @Getter
     @NoArgsConstructor
     public static class Document {
-        @JsonProperty("x")
-        private double latitude;
-        @JsonProperty("y")
+        @JsonProperty("x") //경도
         private double longitude;
+        @JsonProperty("y") //위도
+        private double latitude;
     }
 }

--- a/src/main/java/com/header/header/domain/shop/dto/ShopCreationDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/ShopCreationDTO.java
@@ -1,0 +1,41 @@
+package com.header.header.domain.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+/*샵 생성시 정보를 받는 용도의 DTO*/
+public class ShopCreationDTO {
+
+    @NotBlank(message = "카테고리 유형은 비워둘 수 없습니다")
+    private Integer categoryCode;
+    private Integer adminCode;
+
+    @NotBlank(message = "샵 이름은 비워둘 수 없습니다")
+    @Size(max = 50, message = "샵 이름은 최대 50자까지 입력 가능합니다")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]*$", message = "상점 이름은 한글, 영문, 숫자, 공백만 포함할 수 있습니다")
+    private String shopName;
+
+    @NotBlank(message = "전화번호는 비워둘 수 없습니다")
+    @Size(max = 20, message = "전화번호는 최대 20자까지 입력 가능합니다")
+    private String shopPhone;
+
+    @NotBlank(message = "샵 주소는 비워둘 수 없습니다")
+    @Size(max = 255, message = "샵 주소는 최대 255자까지 입력 가능합니다")
+    private String shopLocation;
+    private Double shopLong;
+    private Double shopLa;
+
+    @NotBlank(message = "샵 상태는 비워둘 수 없습니다")
+    private String shopStatus;
+
+    @NotBlank(message = "영업 시작 시간은 비워둘 수 없습니다")
+    private String shopOpen;
+
+    @NotBlank(message = "영업 종료 시간은 비워둘 수 없습니다")
+    private String shopClose;
+}

--- a/src/main/java/com/header/header/domain/shop/dto/ShopSearchConditionDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/ShopSearchConditionDTO.java
@@ -1,0 +1,13 @@
+package com.header.header.domain.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ShopSearchConditionDTO {
+    private String keyword;
+    private Integer categoryCode;
+    private Double userLa; // 사용자 위도
+    private Double userLong; // 사용자 경도
+}

--- a/src/main/java/com/header/header/domain/shop/dto/ShopSummaryResponseDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/ShopSummaryResponseDTO.java
@@ -1,0 +1,20 @@
+package com.header.header.domain.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ShopSummaryResponseDTO {
+
+    private String shopName;
+    private String shopPhone;
+    private String shopLocation;
+    private String categoryName;
+    private Double distance; // 사용자 기준 거리 (프론트에 전달)
+
+    //조회 데이터: Shop - 샵 이름, 전화번호, 주소/ CategoryCode - 카테고리 이름 (예: 미용실)
+
+}

--- a/src/main/java/com/header/header/domain/shop/dto/ShopUpdateDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/ShopUpdateDTO.java
@@ -1,0 +1,42 @@
+package com.header.header.domain.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+/*샵을 업데이트 할 때 사용되는 DTO, CreationDTO와 다른 점: shopCode 필요*/
+public class ShopUpdateDTO {
+
+    private Integer shopCode;
+
+    @NotBlank(message = "카테고리 유형은 비워둘 수 없습니다")
+    private Integer categoryCode;
+
+    @NotBlank(message = "샵 이름은 비워둘 수 없습니다")
+    @Size(max = 50, message = "샵 이름은 최대 50자까지 입력 가능합니다")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]*$", message = "상점 이름은 한글, 영문, 숫자, 공백만 포함할 수 있습니다")
+    private String shopName;
+
+    @NotBlank(message = "전화번호는 비워둘 수 없습니다")
+    @Size(max = 20, message = "전화번호는 최대 20자까지 입력 가능합니다")
+    private String shopPhone;
+
+    @NotBlank(message = "샵 주소는 비워둘 수 없습니다")
+    @Size(max = 255, message = "샵 주소는 최대 255자까지 입력 가능합니다")
+    private String shopLocation;
+    private Double shopLong;
+    private Double shopLa;
+
+    @NotBlank(message = "샵 상태는 비워둘 수 없습니다")
+    private String shopStatus;
+
+    @NotBlank(message = "영업 시작 시간은 비워둘 수 없습니다")
+    private String shopOpen;
+
+    @NotBlank(message = "영업 종료 시간은 비워둘 수 없습니다")
+    private String shopClose;
+}

--- a/src/main/java/com/header/header/domain/shop/entity/Shop.java
+++ b/src/main/java/com/header/header/domain/shop/entity/Shop.java
@@ -1,25 +1,34 @@
 package com.header.header.domain.shop.entity;
 
+import com.header.header.domain.menu.entity.MenuCategory;
 import com.header.header.domain.shop.converter.ShopStatusConverter;
 import com.header.header.domain.shop.enums.ShopStatus;
+import com.header.header.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicInsert;
+import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Table(name="tbl_shop")
 @Getter
 @NoArgsConstructor( access = AccessLevel.PROTECTED)
-@DynamicInsert //쿼리를 실행할 때 값이 null인 필드 자동 제외하여 default값 반영
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Shop {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer shopCode;
-    private Integer categoryCode;
-    private Integer adminCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_code")
+    private ShopCategory categoryInfo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_code")
+    private User adminInfo;
+
     private String shopName;
     private String shopPhone;
     private String shopLocation;
@@ -33,12 +42,30 @@ public class Shop {
     private String shopClose;
     private Boolean isActive;
 
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shopCode")
+    private List<MenuCategory> menuCategoryList;
+
     public void deactivateShop() {
 
         /* Shop을 논리적 삭제 (활성 상태 -> False 변환)하는 메소드
         *  Setter가 아니기 때문에 엔티티 내부에 직접 작성하였어도 보안 위협 낮음*/
 
         this.isActive = false;
+    }
+
+    public void updateShopInfo(
+            ShopCategory categoryInfo, String shopName, String shopPhone,
+            String shopLocation, Double shopLong, Double shopLa, ShopStatus shopStatus, String shopOpen, String shopClose) {
+        this.categoryInfo = categoryInfo;
+        this.shopName = shopName;
+        this.shopPhone = shopPhone;
+        this.shopLocation = shopLocation;
+        this.shopLong = shopLong;
+        this.shopLa = shopLa;
+        this.shopStatus = shopStatus;
+        this.shopOpen = shopOpen;
+        this.shopClose = shopClose;
     }
 
 }

--- a/src/main/java/com/header/header/domain/shop/enums/ShopErrorCode.java
+++ b/src/main/java/com/header/header/domain/shop/enums/ShopErrorCode.java
@@ -15,7 +15,9 @@ public enum ShopErrorCode {
     SHOP_ALREADY_DEACTIVATED("SHOP_ALREADY_DEACTIVATED", "해당 샵은 이미 비활성화 상태입니다."),
     LOCATION_NOT_FOUND("LOCATION_NOT_FOUND", "잘못된 주소입니다."),
     UNKNOWN_DB_VALUE("UNKNOWN_DB_VALUE", "유효하지 않은 값입니다."),
-    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다.");
+    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다."),
+    SHOP_CATEGORY_NOT_FOUND("SHOP_CATEGORY_NOT_FOUND", "유효하지 않은 카테고리 입니다."),
+    SHOP_IS_EMPTY("SHOP_IS_EMPTY", "보유한 샵이 존재하지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/header/header/domain/shop/enums/ShopStatus.java
+++ b/src/main/java/com/header/header/domain/shop/enums/ShopStatus.java
@@ -1,5 +1,6 @@
 package com.header.header.domain.shop.enums;
 
+import com.header.header.domain.shop.exception.ShopExceptionHandler;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +14,13 @@ public enum ShopStatus {
     CLOSED("휴업중");
 
     private final String dbName;
+
+    public static ShopStatus fromDbName(String dbName) {
+        for (ShopStatus status : ShopStatus.values()) {
+            if (status.getDbName().equals(dbName)) {
+                return status;
+            }
+        }
+        throw new ShopExceptionHandler(ShopErrorCode.UNKNOWN_DB_VALUE);
+    }
 }

--- a/src/main/java/com/header/header/domain/shop/projection/ShopDetailResponse.java
+++ b/src/main/java/com/header/header/domain/shop/projection/ShopDetailResponse.java
@@ -1,0 +1,18 @@
+package com.header.header.domain.shop.projection;
+
+public interface ShopDetailResponse {
+//사용자, 관리자의 샵 상세 조회용 프로젝션
+    String getShopName();
+    String getShopPhone();
+    String getShopLocation();
+    String getShopOpen();
+    String getShopClose();
+    String getShopStatus();
+    String getCategoryName();
+
+
+    String getMenuName();
+    Integer getMenuPrice();
+    Integer getEstTime();
+    String getMenuCategoryName();
+}

--- a/src/main/java/com/header/header/domain/shop/projection/ShopSummary.java
+++ b/src/main/java/com/header/header/domain/shop/projection/ShopSummary.java
@@ -4,12 +4,10 @@ import com.header.header.domain.shop.enums.ShopStatus;
 
 public interface ShopSummary {
 
-    Integer getShopCode();
-    Integer getCategoryCode();
-    Integer getAdminCode();
     String getShopName();
     String getShopPhone();
     String getShopLocation();
-    ShopStatus getShopStatus();
-    Boolean getIsActive();
+    String getCategoryName();
+
+    // 관리자의 요약 조회 데이터: shop - 샵 이름, 샵 전화번호, 샵 주소, category - 카테고리 이름
 }

--- a/src/main/java/com/header/header/domain/shop/repository/ShopCategoryRepository.java
+++ b/src/main/java/com/header/header/domain/shop/repository/ShopCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.header.header.domain.shop.repository;
+
+import com.header.header.domain.shop.entity.ShopCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopCategoryRepository extends JpaRepository<ShopCategory, Integer> {
+}

--- a/src/main/java/com/header/header/domain/shop/service/ShopService.java
+++ b/src/main/java/com/header/header/domain/shop/service/ShopService.java
@@ -1,17 +1,23 @@
 package com.header.header.domain.shop.service;
 
-import com.header.header.domain.shop.dto.MapServiceDTO;
-import com.header.header.domain.shop.dto.ShopDTO;
+import com.header.header.domain.shop.dto.*;
 import com.header.header.domain.shop.entity.Shop;
+import com.header.header.domain.shop.entity.ShopCategory;
 import com.header.header.domain.shop.enums.ShopErrorCode;
+import com.header.header.domain.shop.enums.ShopStatus;
 import com.header.header.domain.shop.exception.*;
 import com.header.header.domain.shop.external.MapService;
+import com.header.header.domain.shop.projection.ShopDetailResponse;
 import com.header.header.domain.shop.projection.ShopSummary;
+import com.header.header.domain.shop.repository.ShopCategoryRepository;
 import com.header.header.domain.shop.repository.ShopRepository;
+import com.header.header.domain.user.entity.User;
 import com.header.header.domain.user.repository.MainUserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,72 +30,150 @@ public class ShopService {
     private final ModelMapper modelMapper;
     private final MapService mapService;
 
-    //User 정보 가져오기 위해 임시 처리 - 머지 & 삭제 후 임포트 구문 수정 예상
+
     private final MainUserRepository userRepository;
 
-    //CREATE
-    @Transactional
-    public ShopDTO createShop(ShopDTO shopDTO) {
-        // getCoordinatesFromAddress -> getCoordinates -> MapService 호출하여 API에 담긴 정보 가져옴
-        MapServiceDTO.Document document = getCoordinatesFromAddress(shopDTO.getShopLocation());
+    private final ShopCategoryRepository shopCategoryRepository;
 
-        shopDTO.setShopLa(document.getLatitude());
-        shopDTO.setShopLong(document.getLongitude());
+    //CREATE 샵 생성
+    public ShopDTO createShop(ShopCreationDTO dto) {
+        /*카테고리 코드 유효성 체크*/
+        ShopCategory category = shopCategoryRepository.findById(dto.getCategoryCode())
+                .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_CATEGORY_NOT_FOUND));
 
-        // Entity -> DTO 변환하여 반환
-        return modelMapper.map(shopRepository.save(modelMapper.map(shopDTO, Shop.class)), ShopDTO.class);
+        /*관리자 유효성 체크*/
+        User admin = userRepository.findById(dto.getAdminCode())
+                .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.ADMIN_NOT_FOUND));
+
+        /*getCoordinatesFromAddress -> getCoordinates -> MapService 호출하여 API에 담긴 정보 가져옴*/
+        MapServiceDTO.Document document = getCoordinatesFromAddress(dto.getShopLocation());
+
+        /*응답받은 document 정보로 shop 위도, 경도 세팅*/
+        dto.setShopLa(document.getLatitude());
+        dto.setShopLong(document.getLongitude());
+
+        /*신규 샵 생성*/
+        Shop shop = Shop.builder()
+                .shopName(dto.getShopName())
+                .categoryInfo(category)
+                .adminInfo(admin)
+                .shopName(dto.getShopName())
+                .shopPhone(dto.getShopPhone())
+                .shopLocation(dto.getShopLocation())
+                .shopLong(dto.getShopLong())
+                .shopLa(dto.getShopLa())
+                .shopOpen(dto.getShopOpen())
+                .shopClose(dto.getShopClose())
+                .shopStatus(ShopStatus.fromDbName(dto.getShopStatus()))
+                .isActive(true)
+                .build();
+
+        return modelMapper.map(shopRepository.save(shop), ShopDTO.class);
     }
 
-    // READ (단건 조회 - 상세 조회)
-    public ShopDTO getShopByShopCode(Integer shopCode) {
+    /*사용자가 검색하는 경우, 페이징 처리된 요약 조회 메소드
+      필터: 카테고리 or 키워드
+      정렬: 기끼운 거리순*/
+    public Page<ShopSummaryResponseDTO> findShopsByCondition(
+            Double lat, Double lon, Integer categoryCode, String keyword, Pageable pageable
+    ) {
+
+        if (lat == null || lon == null) {
+            lat = 37.5145;
+            lon = 127.1067; //사용자가 위치를 허용하지 않았을 때의 기본값, 송파구 중심 좌표
+        }
+
+        return shopRepository.findShopsByCondition(lat, lon, categoryCode, keyword, pageable);
+    }
+
+    /*관리자 혹은 사용자의 상세조회*/
+    public List<ShopDetailResponse> readShopDetailByShopCode(Integer shopCode) {
+
         Shop shop = shopRepository.findById(shopCode)
                 // 존재하지 않는 샵 예외 처리
                 .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
 
-        if (shop.getIsActive() == false) {
-            // 비활성화된 샵 조회 시도 시 예외 처리 -> 테스트시 비활성화되지 않은 샵으로 해야 통과되니 주의
+        // 비활성화된 샵 조회 시도 시 예외 처리
+        if (!shop.getIsActive()) {
             throw new ShopExceptionHandler(ShopErrorCode.SHOP_DEACTIVATED);
         }
-        return modelMapper.map(shop, ShopDTO.class);
+
+        return shopRepository.readShopDetailByShopCode(shopCode);
     }
 
-    //READ (전체 조회 - 요약정보 조회용 SummaryDTO 사용)
-    public List<ShopSummary> findByAdminCodeAndIsActiveTrue(Integer adminCode) {
+    /*관리자가 본인이 보유한 샵을 요약 조회*/
+    public List<ShopSummary> readShopSummaryByAdminCode(Integer adminCode) {
 
         if (userRepository.findById(adminCode).isEmpty()) {
+            //존재하지 않는 UserCode 예외
             throw new ShopExceptionHandler(ShopErrorCode.ADMIN_NOT_FOUND);
-        }
-
-        List<ShopSummary> shopSummaryList = shopRepository.findByAdminCodeAndIsActiveTrue(adminCode);
-
-        if(shopSummaryList.isEmpty()){
+        } else if (shopRepository.readShopSummaryByAdminCode(adminCode).isEmpty()) {
+            //샵을 보유하지 않은 User의 접근 예외
             throw new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND);
         }
 
-        return shopSummaryList;
+        return shopRepository.readShopSummaryByAdminCode(adminCode);
     }
 
-    //UPDATE
+    /*보유한 샵을 수정*/
     @Transactional
-    public ShopDTO updateShop(Integer shopCode, ShopDTO shopInfo) {
-        Shop shop = shopRepository.findById(shopCode)
+    public ShopDTO updateShop(ShopUpdateDTO dto) {
+
+        /*존재하지 않는 샵 예외*/
+        Shop shop = shopRepository.findById(dto.getShopCode())
                 .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
 
-        if (shop.getIsActive() == false) {
+        /*필드별로 null 체크하여 기존 값 유지, 더티 체킹이 동작하지 않아 처리. 추후 검토 예정*/
+        String shopName = dto.getShopName() != null ? dto.getShopName() : shop.getShopName();
+        String shopPhone = dto.getShopPhone() != null ? dto.getShopPhone() : shop.getShopPhone();
+        String shopLocation = dto.getShopLocation() != null ? dto.getShopLocation() : shop.getShopLocation();
+        String shopOpen = dto.getShopOpen() != null ? dto.getShopOpen() : shop.getShopOpen();
+        String shopClose = dto.getShopClose() != null ? dto.getShopClose() : shop.getShopClose();
 
-            throw new ShopExceptionHandler(ShopErrorCode.SHOP_DEACTIVATED);
-        } else if(!shop.getShopLocation().equals(shopInfo.getShopLocation())){
-
-            /* 주소 설정을 위한 if문
-               기존의 주소와 다를 경우에만 API 서버와 통신하여 DB의 위도, 경도 값을 업데이트 */
-            // getCoordinatesFromAddress -> getCoordinates -> MapService 호출하여 API에 담긴 정보 가져옴
-            MapServiceDTO.Document document = getCoordinatesFromAddress(shopInfo.getShopLocation());
-            shopInfo.setShopLa(document.getLatitude());
-            shopInfo.setShopLong(document.getLongitude());
+        /*존재하지 않는 카테고리 유형 예외*/
+        ShopCategory category = shop.getCategoryInfo();
+        if (dto.getCategoryCode() != null) {
+            category = shopCategoryRepository.findById(dto.getCategoryCode())
+                    .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_CATEGORY_NOT_FOUND));
         }
 
-        // Entity -> DTO 변환하여 반환
-        return modelMapper.map(shopRepository.save(modelMapper.map(shopInfo, Shop.class)), ShopDTO.class);
+        /*비활성화된 샵 예외*/
+        if(!shop.getIsActive()) {
+            throw new ShopExceptionHandler(ShopErrorCode.SHOP_DEACTIVATED);
+        }
+
+        Double shopLa = shop.getShopLa();
+        Double shopLong = shop.getShopLong();
+
+        if (dto.getShopLocation() != null && !shop.getShopLocation().equals(dto.getShopLocation())) {
+
+            /*샵의 주소를 변경했을 경우에만 위도, 경도 값 업데이트*/
+            MapServiceDTO.Document document = getCoordinatesFromAddress(dto.getShopLocation());
+            shopLa = document.getLatitude();
+            shopLong = document.getLongitude();
+        }
+
+        /*Converter 사용으로 if 문 처리*/
+        ShopStatus shopStatus = shop.getShopStatus();
+        if (dto.getShopStatus() != null) {
+            shopStatus = ShopStatus.fromDbName(dto.getShopStatus());
+        } else if (!shop.getShopStatus().equals(shopStatus)) {
+            shopStatus = ShopStatus.fromDbName(shop.getShopStatus().getDbName());
+        }
+
+        shop.updateShopInfo(
+                category,
+                shopName,
+                shopPhone,
+                shopLocation,
+                shopLong,
+                shopLa,
+                shopStatus,
+                shopOpen,
+                shopClose
+        );
+
+        return modelMapper.map(shop,ShopDTO.class);
     }
 
     //DELETE (논리적 삭제)
@@ -125,6 +209,14 @@ public class ShopService {
                 mapServiceDTO.getDocuments().get(0) == null) {
 
             // 잘못된 샵 정보를 입력하려고 시도할 경우 예외 발생
+            throw new ShopExceptionHandler(ShopErrorCode.LOCATION_NOT_FOUND);
+        }
+
+        Double lat = mapServiceDTO.getDocuments().get(0).getLatitude();
+        Double lon = mapServiceDTO.getDocuments().get(0).getLongitude();
+
+        if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+            // ST_Distance_Sphere 함수 사용, 잘못된 위도, 경도 값 제한
             throw new ShopExceptionHandler(ShopErrorCode.LOCATION_NOT_FOUND);
         }
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

- 기존 JOIN을 하지 않고 수행하였던 샵 CRUD 기능을 모두 정상적으로 완료했습니다.

- 샵 생성
- 사용자가 검색하는 경우, 페이징 처리된 샵 요약 리스트 (필터: 카테고리, 키워드/정렬: 가까운 거리순)
- 관리자 혹은 사용자의 상세 조회
- 관리자가 본인이 보유한 샵을 상세 조회
- 보유한 샵 수정
- 논리적 삭제 (isActive = false 전환)
- 예외 처리

- 사용하지 않는 import 삭제
- 용도에 따른 DTO 분리

## 스크린샷 (선택)

<img width="450" height="310" alt="Screenshot 2025-07-12 at 18 52 16" src="https://github.com/user-attachments/assets/b6ed04f0-f246-477c-b515-4f36ca1cbc24" />


 closed #53 
