### PR TITLE
[FIX] #54 User Reservation Create, Read, Delete 기능 완료

### DIFF
--- a/src/main/java/com/header/header/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/header/header/domain/menu/repository/MenuRepository.java
@@ -73,4 +73,14 @@ public interface MenuRepository extends JpaRepository<Menu, Integer> {
 
     /* 메뉴 이름으로 메뉴 엔티티 조회하기 */
     Menu findByMenuName(String menuName);
+
+    /* 메뉴 코드, 샵 코드로 엔티티 조회하기 - 사용자 예약 생성 시 메뉴 유효성 체크 로직에서 사용*/
+    @Query("""
+           SELECT m 
+           FROM Menu m 
+           WHERE m.menuCode = :menuCode 
+           AND m.menuCategory.id.shopCode = :shopCode
+           AND m.isActive = true 
+           """)
+    Menu findByMenuCodeAndShopCodeAndIsActiveTrue(Integer menuCode, Integer shopCode);
 }

--- a/src/main/java/com/header/header/domain/reservation/dto/UserReservationDTO.java
+++ b/src/main/java/com/header/header/domain/reservation/dto/UserReservationDTO.java
@@ -1,31 +1,40 @@
 package com.header.header.domain.reservation.dto;
 
-import com.header.header.domain.reservation.enums.ReservationState;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
 
-import java.sql.Date;
 import java.sql.Time;
+import java.sql.Date;
 
 @Getter
 @Setter
-@ToString
 public class UserReservationDTO {
+    /*새로운 예약 생성시 사용되는 DTO*/
 
-    private Integer resvCode;
+    @NotBlank(message = "유효하지 않은 로그인 정보입니다.")
     private Integer userCode;
+
+    @NotBlank(message = "유효하지 않은 샵 정보입니다.")
     private Integer shopCode;
 
     @NotBlank(message = "시술 메뉴 선택은 필수입니다")
     private Integer menuCode;
 
+    @NotBlank(message = "예약 날짜는 필수입니다.")
+    @FutureOrPresent(message = "예약은 오늘 이후의 날짜만 가능합니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date resvDate;
+
+    @NotBlank(message = "예약 시간은 필수입니다.")
+    @DateTimeFormat(pattern = "HH:mm")
     private Time resvTime;
 
     @Size(max = 255, message = "요청 사항은 최대 255자까지 입력 가능합니다")
     private String userComment;
-    private ReservationState resvState;
+
+    /*예약을 처음 생성할 때 예약 상태는 기본값(예약확정)으로 세팅되므로 필드 제외*/
 }

--- a/src/main/java/com/header/header/domain/reservation/dto/UserReservationSearchConditionDTO.java
+++ b/src/main/java/com/header/header/domain/reservation/dto/UserReservationSearchConditionDTO.java
@@ -1,0 +1,24 @@
+package com.header.header.domain.reservation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.sql.Date;
+
+@Getter
+@Setter
+public class UserReservationSearchConditionDTO {
+
+    @NotBlank(message = "유효하지 않은 로그인 정보입니다.")
+    Integer userCode;
+
+    /*지정된 날짜 형식만 받을 수 있게 체크, null 허용*/
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    Date startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    Date endDate;
+
+}

--- a/src/main/java/com/header/header/domain/reservation/entity/BossReservation.java
+++ b/src/main/java/com/header/header/domain/reservation/entity/BossReservation.java
@@ -7,9 +7,7 @@ import com.header.header.domain.reservation.enums.ReservationState;
 import com.header.header.domain.shop.entity.Shop;
 import com.header.header.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -18,6 +16,7 @@ import java.sql.Time;
 @Table(name="tbl_reservation")
 @Getter
 @NoArgsConstructor( access = AccessLevel.PROTECTED)
+@Builder
 public class BossReservation {
 
     @Id

--- a/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
+++ b/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
@@ -12,7 +12,11 @@ public enum UserReservationErrorCode {
     RESV_ALREADY_DEACTIVATED("RESV_ALREADY_DEACTIVATED", "이미 취소된 예약입니다."),
     RESV_ALREADY_FINISHED("RESV_ALREADY_FINISHED", "이미 완료된 예약은 취소할 수 없습니다."),
     RESV_ALREADY_PAID("RESV_ALREADY_PAID", "결제 완료된 예약은 취소할 수 없습니다."),
-    USER_NOT_FOUND("USER_NOT_FOUND", "유효하지 않은 유저 정보입니다.");
+    USER_NOT_FOUND("USER_NOT_FOUND", "유효하지 않은 사용자 정보입니다."),
+    USER_HAS_LEFT("USER_HAS_LEFT", "탈퇴한 사용자 정보입니다"),
+    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "조회 시작 날짜는 조회 종료 날짜보다 이전이어야 합니다."),
+    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "샵 정보를 찾을 수 없습니다."),
+    MENU_NOT_FOUND("MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/header/header/domain/reservation/projection/UserReservationDetail.java
+++ b/src/main/java/com/header/header/domain/reservation/projection/UserReservationDetail.java
@@ -1,0 +1,21 @@
+package com.header.header.domain.reservation.projection;
+
+public interface UserReservationDetail {
+
+    /*사용자가 예약 내역을 상세조회할 때 쓰이는 프로젝션
+    * 조회 데이터:
+    * Reservation => 예약 날짜, 예약 시간, 예약 상태
+    * Shop => 샵 이름, 샵 주소
+    * Menu => 메뉴 이름
+    * */
+
+    String getResvDate();
+    String getResvTime();
+    String getResvState();
+    String getUserComment();
+    String getShopName();
+    String getShopLocation();
+    String getMenuName();
+    String getUserName();
+    String getUserPhone();
+}

--- a/src/main/java/com/header/header/domain/reservation/projection/UserReservationSummary.java
+++ b/src/main/java/com/header/header/domain/reservation/projection/UserReservationSummary.java
@@ -1,13 +1,14 @@
 package com.header.header.domain.reservation.projection;
 
-import com.header.header.domain.reservation.enums.ReservationState;
-
 public interface UserReservationSummary {
 
-    Integer getResvCode();
-    Integer getUserCode();
-    Integer getShopCode();
+    /*사용자가 자신이 예약한 다수의 예약들을 요약 조회하는 프로젝션*/
+
     String getResvDate();
-    ReservationState getResvState();
+    String getResvTime();
+    String getResvState();
+    String getShopName();
+    String getShopLocation();
+    String getMenuName();
 
 }

--- a/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
+++ b/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
@@ -1,14 +1,76 @@
 package com.header.header.domain.reservation.repository;
 
 import com.header.header.domain.reservation.entity.BossReservation;
-import com.header.header.domain.reservation.entity.Reservation;
+import com.header.header.domain.reservation.projection.UserReservationDetail;
 import com.header.header.domain.reservation.projection.UserReservationSummary;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
-public interface UserReservationRepository extends JpaRepository<Reservation, Integer> {
+public interface UserReservationRepository extends JpaRepository<BossReservation, Integer> {
 
-    // 요약 정보(UserReservationSummary)를 위해 Projection Based Interface 방식 사용
-    List<UserReservationSummary> findByUserCode(Integer userCode);
+    /*사용자가 특정 예약에 대한 내역을 상세 조회할 경우
+    * 매개변수 : userCode, resvCode
+    * 조회 데이터:
+    *           예약 날짜/시간/상태/요청사항(코멘트)
+    *           샵  이름/주소
+    *           메뉴 이름
+    *           유저 이름/전화번호
+    * */
+    @Query("""
+        SELECT 
+                r.resvDate AS resvDate,
+                r.resvTime AS resvTime,
+                r.resvState AS resvState,
+                r.userComment AS userComment,
+                s.shopName AS shopName,
+                s.shopLocation AS shopLocation,
+                m.menuName AS menuName,
+                u.userName AS userName,
+                u.userPhone AS userPhone
+        FROM BossReservation r
+        JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
+        JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
+        JOIN User u ON r.userInfo.userCode = u.userCode
+        WHERE u.userCode = :userCode 
+            AND r.resvCode = :resvCode
+    """)
+    Optional<UserReservationDetail> readDetailByUserCodeAndResvCode(Integer userCode, Integer resvCode);
+
+    /*사용자가 자신이 예약한 내역들의 목록을 조회할 경우
+     * 매개변수 : userCode
+     * 조회 데이터:
+     *           예약 날짜/시간/상태
+     *           샵  이름/주소
+     *           메뉴 이름
+     * 데이터 정렬: 최근 날짜 순
+     * */
+
+    @Query("""
+        SELECT 
+            r.resvDate AS resvDate,
+            r.resvTime AS resvTime,
+            r.resvState AS resvState,
+            s.shopName AS shopName,
+            s.shopLocation AS shopLocation,
+            m.menuName AS menuName
+        FROM BossReservation r
+        JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
+        JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
+        WHERE r.userInfo.userCode = :userCode
+            AND (:startDate IS NULL OR r.resvDate >= :startDate)
+            AND (:endDate IS NULL OR r.resvDate <= :endDate)
+        ORDER BY r.resvDate DESC
+    """)
+    List<UserReservationSummary> findResvSummaryByUserCode(
+            @Param("userCode") Integer userCode,
+            @Param("startDate") Date startDate,
+            @Param("endDate") Date endDate
+    );
+
 }

--- a/src/main/java/com/header/header/domain/reservation/service/BossReservationService.java
+++ b/src/main/java/com/header/header/domain/reservation/service/BossReservationService.java
@@ -156,7 +156,8 @@ public class BossReservationService {
         */
 
         // 1 ~ 2번
-        Reservation foundReservation = userReservationRepository.findById(resvCode).orElseThrow(IllegalArgumentException::new);
+        BossReservation foundReservation = userReservationRepository.findById(resvCode).orElseThrow(IllegalArgumentException::new);
+        // Reservation -> BossReservation 컴파일에러 없애기 위해 수정
 
         // 3번
         Menu menu = menuRepository.findByMenuName(inputDTO.getMenuName());
@@ -179,7 +180,8 @@ public class BossReservationService {
     public void cancelReservation(Integer resvCode){
 
         /* 예약 취소 시 물리적 삭제가 아닌 논리적 삭제로 진행하기 -> resvState를 예약 취소로 변경하기 */
-        Reservation foundReservation = userReservationRepository.findById(resvCode).orElseThrow(IllegalArgumentException::new);
+        BossReservation foundReservation = userReservationRepository.findById(resvCode).orElseThrow(IllegalArgumentException::new);
+        // Reservation -> BossReservation 컴파일에러 없애기 위해 수정
 
         foundReservation.cancelReservation();
     }

--- a/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
+++ b/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
@@ -1,20 +1,28 @@
 package com.header.header.domain.reservation.service;
 
 import com.header.header.domain.auth.model.repository.AuthUserRepository;
+import com.header.header.domain.menu.entity.Menu;
+import com.header.header.domain.menu.repository.MenuRepository;
 import com.header.header.domain.reservation.dto.UserReservationDTO;
+import com.header.header.domain.reservation.dto.UserReservationSearchConditionDTO;
 import com.header.header.domain.reservation.entity.BossReservation;
-import com.header.header.domain.reservation.entity.Reservation;
-import com.header.header.domain.reservation.enums.UserReservationErrorCode;
 import com.header.header.domain.reservation.enums.ReservationState;
+import com.header.header.domain.reservation.enums.UserReservationErrorCode;
 import com.header.header.domain.reservation.exception.UserReservationExceptionHandler;
+import com.header.header.domain.reservation.projection.UserReservationDetail;
 import com.header.header.domain.reservation.projection.UserReservationSummary;
 import com.header.header.domain.reservation.repository.UserReservationRepository;
+import com.header.header.domain.shop.entity.Shop;
+import com.header.header.domain.shop.repository.ShopRepository;
+import com.header.header.domain.user.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.sql.Date; // util.Date -> 날짜 및 시간 (1970 기준 밀리초 포함), 오래된 범용 타입, 사용 지양
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,57 +30,139 @@ public class UserReservationService {
 
     private final UserReservationRepository userReservationRepository;
     private final ModelMapper modelMapper;
-
-    //User 정보 위해 임시 처리
     private final AuthUserRepository userRepository;
+    private final ShopRepository shopRepository;
+    private final MenuRepository menuRepository;
 
-    // CREATE
-    @Transactional
-    public UserReservationDTO createUserReservation(UserReservationDTO resvInfo) {
+    /*사용자가 자신의 예약 내역을 상세 조회할 경우*/
+    public Optional<UserReservationDetail> readDetailByUserCodeAndResvCode(Integer userCode, Integer resvCode) {
 
-        Reservation reservation = modelMapper.map(resvInfo, Reservation.class);
+            /*사용자 정보가 존재하지 않을 경우 예외*/
+        User user = userRepository.findById(userCode)
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND));
 
-        Reservation savedReservation = userReservationRepository.save(reservation);
+        if (user.isLeave()) {
 
-        return modelMapper.map(savedReservation, UserReservationDTO.class);
-    }
+            /*사용자가 탈퇴한 경우 예외*/
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.USER_HAS_LEFT);
+        } else if (userReservationRepository.findById(resvCode).isEmpty()) {
 
-    //READ (단건 조회 - 상세 조회)
-    public UserReservationDTO getReservationByResvCode(Integer ResvCode) {
-        Reservation reservation = userReservationRepository.findById(ResvCode)
-                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.RESV_NOT_FOUND));
-        return modelMapper.map(reservation, UserReservationDTO.class);
-    }
-
-    //READ (전체 조회 - UserReservationSummaryDTO)
-    public List<UserReservationSummary> findByUserCode(Integer userCode) {
-
-        if (userRepository.findById(userCode).isEmpty()) {
-            throw new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND);
+            /*예약 정보가 존재하지 않을 경우 예외*/
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.RESV_NOT_FOUND);
         }
 
-        return userReservationRepository.findByUserCode(userCode);
+        return userReservationRepository.readDetailByUserCodeAndResvCode(userCode, resvCode);
     }
 
-    //DELETE (논리적 삭제)
-    @Transactional
-    public UserReservationDTO cancelReservation(Integer resvCode) {
-        Reservation reservation = userReservationRepository.findById(resvCode)
-                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.RESV_NOT_FOUND));
+    /*사용자가 자신이 예약한 내역들의 목록을 조회할 경우*/
+    public List<UserReservationSummary> findResvSummaryByUserCode(
+            UserReservationSearchConditionDTO conditionDTO)
+    {
+        /*유효성 체크가 된 데이터들 한개씩 꺼내오기*/
+        Integer userCode = conditionDTO.getUserCode();
+        Date startDate = conditionDTO.getStartDate();
+        Date endDate = conditionDTO.getEndDate();
 
+        /*날짜 조회 필터를 사용할 경우*/
+        if (startDate != null || endDate != null) {
+
+            /*조회 시작 날짜가 조회 종료 날짜보다 이후인 경우 예외*/
+            if (!startDate.before(endDate)) {
+                throw new UserReservationExceptionHandler(UserReservationErrorCode.INPUT_DATE_WRONG);
+            }
+        }
+
+
+        /*사용자 정보가 존재하지 않을 경우 예외*/
+        User user = userRepository.findById(userCode)
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND));
+
+        /*사용자가 탈퇴한 경우 예외*/
+        if (user.isLeave()) {
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.USER_HAS_LEFT);
+        }
+
+        return userReservationRepository.findResvSummaryByUserCode(userCode, startDate, endDate);
+    }
+
+    /* 새로운 예약 생성, 반환값은 상세조회 프로젝션 인터페이스 사용 */
+    @Transactional
+    public Optional<UserReservationDetail> createReservation(
+            UserReservationDTO dto
+    ) {
+        /* 엔티티 유효성 검사*/
+        Integer userCode = dto.getUserCode();
+        Integer shopCode = dto.getShopCode();
+        Integer menuCode = dto.getMenuCode();
+
+        /*유효하지 않은 사용자 정보일 경우 예외*/
+        User user = userRepository.findById(userCode)
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND));
+
+        /*유효하지 않은 샵 정보일 경우 예외*/
+        Shop shop = shopRepository.findById(shopCode)
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.SHOP_NOT_FOUND));
+
+        /*  유효하지 않는 메뉴 정보 예외
+            1) 해당 샵이 가지고 있지 않은 메뉴인 경우
+            2) 비활성화된 메뉴인 경우*/
+        Menu menu = menuRepository.findByMenuCodeAndShopCodeAndIsActiveTrue(menuCode, shopCode);
+        if (menu == null) {
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.MENU_NOT_FOUND);
+        }
+
+        BossReservation newReservation = BossReservation
+                .builder()
+                .userInfo(user)
+                .shopInfo(shop)
+                .menuInfo(menu)
+                .resvDate(dto.getResvDate())
+                .resvTime(dto.getResvTime())
+                .userComment(dto.getUserComment())
+                .resvState(ReservationState.APPROVE)
+                // 예약을 생성할 경우 기본값은 "예약확정"
+                .build();
+
+        /* 예약 생성 */
+        userReservationRepository.save(newReservation);
+
+        return userReservationRepository.readDetailByUserCodeAndResvCode(userCode, newReservation.getResvCode());
+    }
+
+    /* 논리적 삭제 */
+    @Transactional
+    public void cancelReservation(Integer userCode, Integer resvCode) {
+
+        /* 사용자 정보 유효성 검사 */
+        User user = userRepository.findById(userCode)
+                /*존재하지 않는 유저 정보 예외*/
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND));
+
+        if (user.isLeave()) {
+            /*탈퇴한 유저 정보 예외*/
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.USER_HAS_LEFT);
+        }
+
+        /*예약 정보 유효성 검사*/
+        BossReservation reservation = userReservationRepository.findById(resvCode)
+
+                /*존재하지 않는 예약 정보 예외*/
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.RESV_NOT_FOUND));
         if (reservation.getResvState() == ReservationState.CANCEL) {
+
+            /*이미 취소된 예약 정보 예외*/
             throw new UserReservationExceptionHandler(UserReservationErrorCode.RESV_ALREADY_DEACTIVATED);
         } else if (reservation.getResvState() == ReservationState.FINISH) {
+
+            /*시술 완료된 예약 정보 예외*/
             throw new UserReservationExceptionHandler(UserReservationErrorCode.RESV_ALREADY_FINISHED);
         } else {
+
+            /*위 유효성 검사를 모두 통과했을 경우, 엔티티 내부 취소 메소드 사용*/
             reservation.cancelReservation();
         }
 
         userReservationRepository.save(reservation);
-
-        return modelMapper.map(reservation, UserReservationDTO.class);
     }
-
-
 
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
- Boss Reservation 담당자와 상의 및 엔티티 결합 후 BossReservation 엔티티 기준으로 기능을 수정 및 구현하였습니다.
- 기존 기능 구현에서 착오로 제외하였던 JOIN 기능을 모두 정상적으로 구현하였습니다.
- User Reservation 관련 Create, Read, Delete 기능 구현하였습니다.
    - 사용자가 새로운 예약 생성하는 기능
    - 사용자가 자신이 예약했던 내용들을 모두 리스트 형태로 조회하는 기능 (최근 날짜 순으로 조회)
    - 사용자가 자신이 예약했던 특정 예약에 대한 상세 내용을 조회하는 기능 
    - 사용자가 자신이 예약했던 내역을 삭제하는 기능 (논리적 삭제, 예약상태가 "예약취소"로 변경)
   
## 💬리뷰 요구사항(선택)

팀원과 상의 후 예약의 경우, 만약 수정이 필요하다면 삭제 후 재예약을 하도록 하고 직접적인 수정 기능은 제외하였습니다.   
자신의 예약 내역을 불러올 때, 예약 내역이 너무 없어서 (보통 유저 당 한 개) 제 더미데이터만 임시로 추가하여 테스트 확인 하였습니다. 혹시 DB의 예약 테이블에 특정 유저에 대한 예약 내역을 20줄 정도 추가해도 괜찮을까요? 

## 스크린샷 (선택)
<img width="306" height="293" alt="Screenshot 2025-07-13 at 20 28 28" src="https://github.com/user-attachments/assets/793baf94-2637-45d7-9c86-d71e6939b3a9" />

closed #54 

 
