### PR TITLE
[FEATURE] #77 Shop Holiday CRUD 기능 구현 완료

### DIFF
--- a/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
+++ b/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
@@ -1,45 +1,46 @@
 package com.header.header.domain.reservation.repository;
 
 import com.header.header.domain.reservation.entity.BossReservation;
+import com.header.header.domain.reservation.enums.ReservationState;
 import com.header.header.domain.reservation.projection.UserReservationDetail;
 import com.header.header.domain.reservation.projection.UserReservationSummary;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.sql.Date;
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 public interface UserReservationRepository extends JpaRepository<BossReservation, Integer> {
 
     /*사용자가 특정 예약에 대한 내역을 상세 조회할 경우
-    * 매개변수 : userCode, resvCode
-    * 조회 데이터:
-    *           예약 날짜/시간/상태/요청사항(코멘트)
-    *           샵  이름/주소
-    *           메뉴 이름
-    *           유저 이름/전화번호
-    * */
+     * 매개변수 : userCode, resvCode
+     * 조회 데이터:
+     *           예약 날짜/시간/상태/요청사항(코멘트)
+     *           샵  이름/주소
+     *           메뉴 이름
+     *           유저 이름/전화번호
+     * */
     @Query("""
-        SELECT 
-                r.resvDate AS resvDate,
-                r.resvTime AS resvTime,
-                r.resvState AS resvState,
-                r.userComment AS userComment,
-                s.shopName AS shopName,
-                s.shopLocation AS shopLocation,
-                m.menuName AS menuName,
-                u.userName AS userName,
-                u.userPhone AS userPhone
-        FROM BossReservation r
-        JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
-        JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
-        JOIN User u ON r.userInfo.userCode = u.userCode
-        WHERE u.userCode = :userCode 
-            AND r.resvCode = :resvCode
-    """)
+                SELECT 
+                        r.resvDate AS resvDate,
+                        r.resvTime AS resvTime,
+                        r.resvState AS resvState,
+                        r.userComment AS userComment,
+                        s.shopName AS shopName,
+                        s.shopLocation AS shopLocation,
+                        m.menuName AS menuName,
+                        u.userName AS userName,
+                        u.userPhone AS userPhone
+                FROM BossReservation r
+                JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
+                JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
+                JOIN User u ON r.userInfo.userCode = u.userCode
+                WHERE u.userCode = :userCode 
+                    AND r.resvCode = :resvCode
+            """)
     Optional<UserReservationDetail> readDetailByUserCodeAndResvCode(Integer userCode, Integer resvCode);
 
     /*사용자가 자신이 예약한 내역들의 목록을 조회할 경우
@@ -52,31 +53,53 @@ public interface UserReservationRepository extends JpaRepository<BossReservation
      * */
 
     @Query("""
-        SELECT 
-            r.resvDate AS resvDate,
-            r.resvTime AS resvTime,
-            r.resvState AS resvState,
-            s.shopName AS shopName,
-            s.shopLocation AS shopLocation,
-            m.menuName AS menuName
-        FROM BossReservation r
-        JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
-        JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
-        WHERE r.userInfo.userCode = :userCode
-            AND (:startDate IS NULL OR r.resvDate >= :startDate)
-            AND (:endDate IS NULL OR r.resvDate <= :endDate)
-        ORDER BY r.resvDate DESC
-    """)
+                SELECT 
+                    r.resvDate AS resvDate,
+                    r.resvTime AS resvTime,
+                    r.resvState AS resvState,
+                    s.shopName AS shopName,
+                    s.shopLocation AS shopLocation,
+                    m.menuName AS menuName
+                FROM BossReservation r
+                JOIN Shop s ON r.shopInfo.shopCode = s.shopCode
+                JOIN Menu m ON r.menuInfo.menuCode = m.menuCode
+                WHERE r.userInfo.userCode = :userCode
+                    AND (:startDate IS NULL OR r.resvDate >= :startDate)
+                    AND (:endDate IS NULL OR r.resvDate <= :endDate)
+                ORDER BY r.resvDate DESC
+            """)
     List<UserReservationSummary> findResvSummaryByUserCode(
             @Param("userCode") Integer userCode,
             @Param("startDate") Date startDate,
             @Param("endDate") Date endDate
     );
 
+    /* 휴일 날짜가 이미 예약 상에 존재하는지 검증하는 용도 (일시적 휴일)*/
     @Query("""
-    SELECT r 
-    FROM BossReservation r
-    """)
-    Optional<BossReservation> findByResvDate();
+            SELECT COUNT (r) > 0
+            FROM BossReservation r
+            WHERE r.shopInfo.shopCode = :shopCode
+            AND r.resvDate BETWEEN :startDate AND :endDate
+            AND NOT r.resvState = 'CANCEL'
+            """)
+    boolean isExistDateBetweenHols(
+            @Param("shopCode") Integer shopCode,
+            @Param("startDate") Date startDate,
+            @Param("endDate") Date endDate
+    );
+
+    /* 휴일 날짜가 이미 예약 상에 존재하는지 검증하는 용도 (반복적 휴일, 반복문으로 검증)*/
+    @Query("""
+           SELECT COUNT(r) > 0
+           FROM BossReservation r
+           WHERE r.shopInfo.shopCode = :shopCode
+           AND r.resvDate = :resvDate
+           AND NOT r.resvState = 'CANCEL'
+           """)
+    boolean isExistRepeatHols(
+            @Param("shopCode") Integer shopCode,
+            @Param("resvDate") Date resvDate
+    );
+
 
 }

--- a/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
+++ b/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
@@ -73,4 +73,10 @@ public interface UserReservationRepository extends JpaRepository<BossReservation
             @Param("endDate") Date endDate
     );
 
+    @Query("""
+    SELECT r 
+    FROM BossReservation r
+    """)
+    Optional<BossReservation> findByResvDate();
+
 }

--- a/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
+++ b/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
@@ -13,6 +13,8 @@ import com.header.header.domain.reservation.projection.UserReservationDetail;
 import com.header.header.domain.reservation.projection.UserReservationSummary;
 import com.header.header.domain.reservation.repository.UserReservationRepository;
 import com.header.header.domain.shop.entity.Shop;
+import com.header.header.domain.shop.entity.ShopHoliday;
+import com.header.header.domain.shop.repository.ShopHolidayRepository;
 import com.header.header.domain.shop.repository.ShopRepository;
 import com.header.header.domain.user.entity.User;
 import jakarta.transaction.Transactional;
@@ -21,6 +23,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.sql.Date; // util.Date -> 날짜 및 시간 (1970 기준 밀리초 포함), 오래된 범용 타입, 사용 지양
+import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +36,7 @@ public class UserReservationService {
     private final AuthUserRepository userRepository;
     private final ShopRepository shopRepository;
     private final MenuRepository menuRepository;
+    private final ShopHolidayRepository shopHolidayRepository;
 
     /*사용자가 자신의 예약 내역을 상세 조회할 경우*/
     public Optional<UserReservationDetail> readDetailByUserCodeAndResvCode(Integer userCode, Integer resvCode) {
@@ -163,6 +167,31 @@ public class UserReservationService {
         }
 
         userReservationRepository.save(reservation);
+    }
+
+    /*사용자가 접근하려는 날짜가 휴일인지 검증하는 메소드
+     * */
+    public boolean isHoliday(Integer shopCode, Date dateToScan) {
+
+        /*임시 휴일 확인 - 단 하루만 검사하는 쿼리 */
+        if (shopHolidayRepository.isTempHoliday(shopCode, dateToScan)) return true;
+
+        /*정기 휴일 확인 - 스캔하려는 날짜보다 이전에 설정된 휴일이 있는지 확인 */
+        List<ShopHoliday> repeatHols = shopHolidayRepository.findRegHoliday(shopCode, dateToScan);
+
+        /* 반환된 값이 비어있지 않을 때만 검증 */
+        if (!repeatHols.isEmpty()) {
+            /*java.time의 요일 계산 클래스*/
+            DayOfWeek day = dateToScan.toLocalDate().getDayOfWeek();
+            for (ShopHoliday hol : repeatHols) {
+                if (hol.getHolStartDate().toLocalDate().getDayOfWeek() == day) {
+                    return true;
+                }
+            }
+        }
+
+        /* 휴일 아님 false 반환*/
+        return false;
     }
 
 }

--- a/src/main/java/com/header/header/domain/shop/dto/CreateHolReqDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/CreateHolReqDTO.java
@@ -1,0 +1,26 @@
+package com.header.header.domain.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.sql.Date;
+
+@Setter
+@Getter
+public class CreateHolReqDTO {
+
+    @NotBlank(message = "샵 정보가 유효하지 않습니다.")
+    private Integer shopCode; //샵 코드가 휴일 생성할 때 꼭 필요한가?
+
+    @NotBlank(message = "휴일 시작 날짜는 비워둘 수 없습니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date endDate;
+
+    @NotBlank
+    boolean isHolRepeat;
+}

--- a/src/main/java/com/header/header/domain/shop/dto/HolCreationDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/HolCreationDTO.java
@@ -1,5 +1,6 @@
 package com.header.header.domain.shop.dto;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,18 +10,21 @@ import java.sql.Date;
 
 @Setter
 @Getter
-public class CreateHolReqDTO {
+public class HolCreationDTO {
+    // 휴일 생성시 사용하는 DTO
 
     @NotBlank(message = "샵 정보가 유효하지 않습니다.")
     private Integer shopCode; //샵 코드가 휴일 생성할 때 꼭 필요한가?
 
     @NotBlank(message = "휴일 시작 날짜는 비워둘 수 없습니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @FutureOrPresent(message = "과거 날짜는 설정할 수 없습니다.")
     private Date startDate;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @FutureOrPresent(message = "과거 날짜는 설정할 수 없습니다.")
     private Date endDate;
 
     @NotBlank
-    boolean isHolRepeat;
+    private Boolean isHolRepeat;
 }

--- a/src/main/java/com/header/header/domain/shop/dto/HolResDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/HolResDTO.java
@@ -1,0 +1,20 @@
+package com.header.header.domain.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.sql.Date;
+
+@Setter
+@Getter
+@ToString //테스트용
+public class HolResDTO {
+    private Integer shopHolCode;
+    private Integer shopCode;
+    private Date holStartDate;
+    private Date holEndDate;
+    private Boolean isHolRepeat;
+
+    private String description; // 안내문구 예) "매주 {weekOfDay} 휴일이 설정되었습니다 ???
+}

--- a/src/main/java/com/header/header/domain/shop/dto/HolUpdateDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/HolUpdateDTO.java
@@ -1,0 +1,37 @@
+package com.header.header.domain.shop.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.sql.Date;
+
+@Getter
+@Setter
+@Builder //test
+public class HolUpdateDTO {
+    /*임시 휴일 업데이트*/
+
+    // Creation + shopHolCode
+    @NotBlank(message = "샵 휴일 정보가 유효하지 않습니다.")
+    private Integer shopHolCode;
+
+    @NotBlank(message = "샵 정보가 유효하지 않습니다.")
+    private Integer shopCode;
+
+    @NotBlank(message = "휴일 시작 날짜는 비워둘 수 없습니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @FutureOrPresent(message = "과거 날짜는 설정할 수 없습니다.")
+    private Date startDate;
+
+    @NotBlank(message = "휴일 종료 날짜는 비워둘 수 없습니다.")
+    @FutureOrPresent(message = "과거 날짜는 설정할 수 없습니다.")
+    private Date endDate;
+
+    @NotBlank
+    private Boolean isHolRepeat;
+
+}

--- a/src/main/java/com/header/header/domain/shop/dto/ShopHolidayDTO.java
+++ b/src/main/java/com/header/header/domain/shop/dto/ShopHolidayDTO.java
@@ -1,0 +1,8 @@
+package com.header.header.domain.shop.dto;
+
+public class ShopHolidayDTO {
+
+    public class createHolDTO {
+        private Integer shopCode;
+    }
+}

--- a/src/main/java/com/header/header/domain/shop/entity/ShopHoliday.java
+++ b/src/main/java/com/header/header/domain/shop/entity/ShopHoliday.java
@@ -29,4 +29,12 @@ public class ShopHoliday {
        1) true: startDate + 7 한 값을 곱해줌, endDate null 허용
        2) false: endDate null 불허 */
 
+    public void updateHolidayInfo(
+            Date startDate, Date endDate, Boolean isHolRepeat
+    ) {
+        this.holStartDate = startDate;
+        this.holEndDate = endDate;
+        this.isHolRepeat = isHolRepeat;
+    }
+
 }

--- a/src/main/java/com/header/header/domain/shop/entity/ShopHoliday.java
+++ b/src/main/java/com/header/header/domain/shop/entity/ShopHoliday.java
@@ -19,7 +19,7 @@ public class ShopHoliday {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_code")
-    private Shop shopCode;
+    private Shop shopInfo;
 
     private Date holStartDate; // not null
     private Date holEndDate; //nullable

--- a/src/main/java/com/header/header/domain/shop/enums/ShopHolidayErrorCode.java
+++ b/src/main/java/com/header/header/domain/shop/enums/ShopHolidayErrorCode.java
@@ -1,0 +1,17 @@
+package com.header.header.domain.shop.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShopHolidayErrorCode {
+
+    DATE_UNAVAILABLE("DATE_UNAVAILABLE", "해당 날짜는 예약이 불가능합니다."),
+    DATE_HAS_RESV("DATE_HAS_RESV", "해당 날짜에는 예약이 존재합니다. 예약을 취소한 후 다시 시도하세요."),
+    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "휴일 시작 날짜는 휴일 종료 날짜보다 앞이어야 합니다."),
+    HOL_NOT_FOUND("HOL_NOT_FOUND", "수정할 휴일 정보를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/header/header/domain/shop/exception/ShopHolidayExceptionHandler.java
+++ b/src/main/java/com/header/header/domain/shop/exception/ShopHolidayExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.header.header.domain.shop.exception;
+
+import com.header.header.domain.shop.enums.ShopHolidayErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ShopHolidayExceptionHandler extends RuntimeException {
+    private final ShopHolidayErrorCode shopHolidayErrorCode;
+
+    public ShopHolidayExceptionHandler(ShopHolidayErrorCode shopHolidayErrorCode) {
+        super(shopHolidayErrorCode.getMessage());
+        this.shopHolidayErrorCode = shopHolidayErrorCode;
+    }
+
+    public ShopHolidayExceptionHandler(ShopHolidayErrorCode shopHolidayErrorCode, String message) {
+        super(message);
+        this.shopHolidayErrorCode = shopHolidayErrorCode;
+    }
+}

--- a/src/main/java/com/header/header/domain/shop/projection/ShopHolidayInfo.java
+++ b/src/main/java/com/header/header/domain/shop/projection/ShopHolidayInfo.java
@@ -1,0 +1,12 @@
+package com.header.header.domain.shop.projection;
+
+public interface ShopHolidayInfo {
+
+    // 샵 별 휴일 정보를 리스트 형식으로 보여줄 때 사용
+
+    Integer getShopCode(); // 프론트에게 값 넘겨줄 때 필요
+    String getHolStartDate();
+    String getHolEndDate();
+    Boolean getIsHolRepeat();
+
+}

--- a/src/main/java/com/header/header/domain/shop/repository/ShopHolidayRepository.java
+++ b/src/main/java/com/header/header/domain/shop/repository/ShopHolidayRepository.java
@@ -1,0 +1,40 @@
+package com.header.header.domain.shop.repository;
+
+import com.header.header.domain.shop.entity.ShopHoliday;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.sql.Date;
+import java.util.List;
+
+public interface ShopHolidayRepository extends JpaRepository<ShopHoliday, Integer> {
+
+    /*특정 가게에 설정된 모든 휴일 조회*//*
+    List<ShopHoliday> findByShopCode(Integer shopCode);*/
+
+    /*특정 날짜가 일시 휴일인지 확인하는 검증용 쿼리
+    * 입력한 날짜가 해당 샵의 holStartDate 부터 holEndDate 사이에 있으면 true 반환
+    * */
+    @Query("""
+            SELECT COUNT(h) > 0
+            FROM ShopHoliday h 
+            WHERE h.shopInfo.shopCode = :shopCode
+            AND h.isHolRepeat = false 
+            AND :dateToScan BETWEEN h.holStartDate AND h.holEndDate
+           """)
+    boolean isTempHoliday (@Param("shopCode") Integer shopCode, @Param("dateToScan") Date dateToScan);
+
+
+    /*특정 날짜가 정기 휴일에 포함될 수 있는지 확인하기 위한 쿼리
+      1) isHolRepeat이 true 이면서 사용자가 입력한 값보다 작은 holStartDate 가 있는 데이터 조회
+      2) 서비스단에서 값이 있는 경우, DayOfWeek(java.time) 메소드 활용하여 요일 확인, 휴일인지 검증 */
+    @Query("""
+            SELECT h
+            FROM ShopHoliday h 
+            WHERE h.shopInfo.shopCode = :shopCode
+            AND h.isHolRepeat = true 
+            AND :dateToScan >= h.holStartDate      
+        """)
+    List<ShopHoliday> findRegHoliday (@Param("shopCode") Integer shopCode, @Param("dateToScan") Date dateToScan);
+}

--- a/src/main/java/com/header/header/domain/shop/service/ShopHolidayService.java
+++ b/src/main/java/com/header/header/domain/shop/service/ShopHolidayService.java
@@ -1,12 +1,16 @@
 package com.header.header.domain.shop.service;
 
 import com.header.header.domain.reservation.repository.UserReservationRepository;
-import com.header.header.domain.shop.dto.CreateHolReqDTO;
+import com.header.header.domain.shop.dto.HolCreationDTO;
 import com.header.header.domain.shop.dto.HolResDTO;
+import com.header.header.domain.shop.dto.HolUpdateDTO;
 import com.header.header.domain.shop.entity.Shop;
 import com.header.header.domain.shop.entity.ShopHoliday;
 import com.header.header.domain.shop.enums.ShopErrorCode;
+import com.header.header.domain.shop.enums.ShopHolidayErrorCode;
 import com.header.header.domain.shop.exception.ShopExceptionHandler;
+import com.header.header.domain.shop.exception.ShopHolidayExceptionHandler;
+import com.header.header.domain.shop.projection.ShopHolidayInfo;
 import com.header.header.domain.shop.repository.ShopHolidayRepository;
 import com.header.header.domain.shop.repository.ShopRepository;
 import jakarta.transaction.Transactional;
@@ -16,6 +20,8 @@ import org.springframework.stereotype.Service;
 
 import java.sql.Date;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -32,17 +38,37 @@ public class ShopHolidayService {
 
     /*새로운 휴일 규칙 생성*/
     @Transactional
-    public HolResDTO createShopHoliday(CreateHolReqDTO dto) {
+    public HolResDTO createShopHoliday(HolCreationDTO dto) {
 
-        /*비어있는지 검증한 shopCode 값 가져오기*/
+        /*DTO에서 검증한 값 가져오기*/
         Integer shopCode = dto.getShopCode();
+        Date startDate = dto.getStartDate();
 
         /*존재하는 샵인지 검증*/
         Shop shop = shopRepository.findById(shopCode)
                 .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
 
         /*해당 날짜에 예약이 있는지 확인*/
-//        if (userReservationRepository) {}
+
+        // 1) 일시적 휴일인 경우
+        if (!dto.getIsHolRepeat()) {
+            //밖에서 값 꺼내려고 시도하면 nullPointException
+            Date endDate = dto.getEndDate();
+            tempDayHasReserved(shopCode, startDate, endDate);
+        } else {
+
+            // 2) 반복하는 휴일인 경우
+            /*
+             * 프론트에서 로직
+             * : 하루만 선택하는 경우 반복 가능, 혹은 요일반복/일정 세팅 선택지 크게 나누기
+             * */
+
+            if (regDayHasReserved(shopCode, startDate)) {
+                // 검증 메소드가 true(예약건 있음) 반환하면 예외 처리
+                throw new ShopHolidayExceptionHandler(ShopHolidayErrorCode.DATE_HAS_RESV);
+            }
+
+        }
 
         /*받은 데이터 빌드*/
         ShopHoliday hol = ShopHoliday
@@ -50,46 +76,158 @@ public class ShopHolidayService {
                 .shopInfo(shop)
                 .holStartDate(dto.getStartDate())
                 .holEndDate(dto.getEndDate())
-                .isHolRepeat(dto.isHolRepeat())
+                .isHolRepeat(dto.getIsHolRepeat())
                 .build();
 
-        /*빌드한 데이터 저장*/
-        ShopHoliday savedHol = shopHolidayRepository.save(hol);
-
-        /*Entity -> DTO 변환하여 반환*/
-        HolResDTO resDTO = modelMapper.map(savedHol, HolResDTO.class);
+        /*Entity 저장 -> DTO 변환하여 반환*/
+        HolResDTO resDTO = modelMapper.map(shopHolidayRepository.save(hol), HolResDTO.class);
 
         /*정기 휴무일 경우 메시지*/
-        if (dto.isHolRepeat()) {
+        if (dto.getIsHolRepeat()) {
             resDTO.setDescription("정기 휴무일이 정상적으로 반영되었습니다.");
         } else {
             resDTO.setDescription("휴무일이 정상적으로 반영되었습니다.");
         }
 
-        return modelMapper.map(savedHol, HolResDTO.class);
+        return resDTO;
     }
 
-    /*사용자가 접근하려는 날짜가 휴일인지 검증하는 메소드*/
-    public boolean isHoliday(Integer shopCode, Date dateToScan) {
+    public HolResDTO updateShopHoliday(HolUpdateDTO dto) {
 
-        /*1. 임시 휴일 확인*/
-        if (shopHolidayRepository.isTempHoliday(shopCode, dateToScan)) return true;
+        // validated data from dto
+        Integer shopHolCode = dto.getShopHolCode();
+        Integer shopCode = dto.getShopCode();
+        Date startDate = dto.getStartDate();
 
-        /*2. 정기 휴일 확인*/
-        List<ShopHoliday> repeatHols = shopHolidayRepository.findRegHoliday(shopCode, dateToScan);
+        // ID로 기존 휴일 Entity를 조회
+        ShopHoliday hol = shopHolidayRepository.findById(shopHolCode)
+                .orElseThrow(() -> new ShopHolidayExceptionHandler(ShopHolidayErrorCode.HOL_NOT_FOUND));
 
-        /* 반환된 값이 비어있지 않을 때만 검증 */
-        if (!repeatHols.isEmpty()) {
-            /*java.time의 요일 계산 클래스*/
-            DayOfWeek day = dateToScan.toLocalDate().getDayOfWeek();
-            for (ShopHoliday hol : repeatHols) {
-                if (hol.getHolStartDate().toLocalDate().getDayOfWeek() == day) {
-                    return true;
-                }
+        /* 해당 날짜에 예약이 있는지 확인, 생성일 때와 똑같음 */
+        // 1) 일시적 휴일인 경우
+        if (!dto.getIsHolRepeat()) {
+            Date endDate = dto.getEndDate();
+            tempDayHasReserved(shopCode, startDate, endDate);
+        } else {
+
+            // 2) 반복하는 휴일인 경우
+            /*
+             * 프론트에서 로직
+             * : 하루만 선택하는 경우 반복 가능, 혹은 요일반복/일정 세팅 선택지 크게 나누기
+             * */
+
+            if (regDayHasReserved(shopCode, startDate)) {
+                // 검증 메소드가 true(예약건 있음) 반환하면 예외 처리
+                throw new ShopHolidayExceptionHandler(ShopHolidayErrorCode.DATE_HAS_RESV);
+            }
+
+        }
+
+        // Entity에 비즈니스 로직을 위임하여 상태 변경
+        hol.updateHolidayInfo(
+                dto.getStartDate(),
+                dto.getEndDate(),
+                dto.getIsHolRepeat()
+        );
+
+        // 변경된 Entity는 @Transactional에 의해 자동으로 DB에 반영(dirty checking)
+
+        /*Entity 저장 -> DTO 변환하여 반환*/
+        HolResDTO resDTO = modelMapper.map(shopHolidayRepository.save(hol), HolResDTO.class);
+
+        /*정기 휴무일 경우 메시지*/
+        if (dto.getIsHolRepeat()) {
+            resDTO.setDescription("정기 휴무일이 정상적으로 반영되었습니다.");
+        } else {
+            resDTO.setDescription("휴무일이 정상적으로 반영되었습니다.");
+        }
+
+        return resDTO;
+    }
+
+    /*각각의 샵이 가진 휴일 정보를 불러옴*/
+    public List<ShopHolidayInfo> getShopHolidayInfo(Integer shopCode) {
+
+        LocalDate getToday = LocalDate.now();
+        Date today = Date.valueOf(getToday); //오늘 날짜 구하기
+
+        // 존재하지 않는 샵이면 예외
+        Shop shop = shopRepository.findById(shopCode)
+                .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
+
+        return shopHolidayRepository.getShopHolidayInfo(shopCode, today);
+    }
+
+    // 휴일 정보 삭제, 물리적 삭제
+    @Transactional
+    public void deleteShopHoliday(Integer shopCode, Integer shopHolCode) {
+        //존재하지 않는 휴일 정보일 경우 예외
+        ShopHoliday hol = shopHolidayRepository.findById(shopHolCode)
+                .orElseThrow(() -> new ShopHolidayExceptionHandler(ShopHolidayErrorCode.HOL_NOT_FOUND));
+
+        //존재하지 않는 샵 정보 예외, 샵 코드가 더 데이터가 많은 테이블이기 때문에 ShopHoliday 먼저 검증 시도함
+        shopRepository.findById(shopCode)
+                .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
+
+        // 그 샵에 해당하는 휴일 정보가 맞는지 검증
+        if(!shopHolidayRepository.isHolReal(shopCode, shopHolCode)){
+            throw new ShopHolidayExceptionHandler(ShopHolidayErrorCode.HOL_NOT_FOUND);
+        }
+
+        // jpa 기본 메소드로 삭제
+        shopHolidayRepository.delete(hol);
+    }
+
+    /* 반복 휴일인 경우 해당 날짜에 예약이 있는지 확인하는 메소드 */
+    boolean regDayHasReserved(Integer shopCode, Date startDate) {
+
+        // 반복 휴일인 경우
+
+        // 휴일 시작일의 요일 구하기 (DayOfWeek) 사용
+        DayOfWeek dayOfWeek = startDate.toLocalDate().getDayOfWeek();
+
+        // LocalDate의 메소드인 plusWeeks를 사용해 리스트에 저장한 후 검증 = LocalDate 사용한 이유
+        List<LocalDate> dates = new ArrayList<>();
+        LocalDate date = startDate.toLocalDate();
+        for (int i = 0; i < 24; i++) {
+            // 24주, 즉 6개월 반복 (예약은 6개월까지만 가능한 경우라고 가정)
+
+            dates.add(date); //더한 값을 list에 저장
+
+            date = date.plusWeeks(1); // 날짜에 1주씩 더해주는 메소드
+        }
+
+        for (LocalDate duplicated : dates) {
+
+            /*리스트에 추가된 날짜에 예약이 있는지 확인*/
+            boolean isExistRepeatHols = userReservationRepository
+                    .isExistRepeatHols(shopCode, Date.valueOf(duplicated));
+
+            //해당 날짜에 예약이 있으면 true
+            if (isExistRepeatHols) {
+                return true;
             }
         }
 
-        /*3. 확인 메소드를 모두 통과한 경우 false = 휴일 아님 반환*/
+        // 반복문을 빠져나오면 false (해당 날짜에 예약된 건 없음)
         return false;
+
+    }
+
+    /*임시 휴무일 경우 검증하는 로직, 예약 던지지 않으면 원래 메소드로 돌아감*/
+    void tempDayHasReserved(Integer shopCode, Date startDate, Date endDate) {
+
+        /*시작 날짜가 종료 날짜 뒤에 있는 경우 검증*/
+        if (startDate.after(endDate)) {
+            throw new ShopHolidayExceptionHandler(ShopHolidayErrorCode.INPUT_DATE_WRONG);
+        }
+
+        /*예약 있으면 true*/
+        boolean hasReservation = userReservationRepository
+                .isExistDateBetweenHols(shopCode, startDate, endDate);
+
+        if (hasReservation) {
+            throw new ShopHolidayExceptionHandler(ShopHolidayErrorCode.DATE_HAS_RESV);
+        }
     }
 }

--- a/src/main/java/com/header/header/domain/shop/service/ShopHolidayService.java
+++ b/src/main/java/com/header/header/domain/shop/service/ShopHolidayService.java
@@ -1,0 +1,95 @@
+package com.header.header.domain.shop.service;
+
+import com.header.header.domain.reservation.repository.UserReservationRepository;
+import com.header.header.domain.shop.dto.CreateHolReqDTO;
+import com.header.header.domain.shop.dto.HolResDTO;
+import com.header.header.domain.shop.entity.Shop;
+import com.header.header.domain.shop.entity.ShopHoliday;
+import com.header.header.domain.shop.enums.ShopErrorCode;
+import com.header.header.domain.shop.exception.ShopExceptionHandler;
+import com.header.header.domain.shop.repository.ShopHolidayRepository;
+import com.header.header.domain.shop.repository.ShopRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.DayOfWeek;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShopHolidayService {
+
+    private final ShopHolidayRepository shopHolidayRepository;
+    private final ModelMapper modelMapper;
+
+    /* 가게 정보 조회 */
+    private final ShopRepository shopRepository;
+    /* 예약 정보 조회 */
+    private final UserReservationRepository userReservationRepository;
+
+    /*새로운 휴일 규칙 생성*/
+    @Transactional
+    public HolResDTO createShopHoliday(CreateHolReqDTO dto) {
+
+        /*비어있는지 검증한 shopCode 값 가져오기*/
+        Integer shopCode = dto.getShopCode();
+
+        /*존재하는 샵인지 검증*/
+        Shop shop = shopRepository.findById(shopCode)
+                .orElseThrow(() -> new ShopExceptionHandler(ShopErrorCode.SHOP_NOT_FOUND));
+
+        /*해당 날짜에 예약이 있는지 확인*/
+//        if (userReservationRepository) {}
+
+        /*받은 데이터 빌드*/
+        ShopHoliday hol = ShopHoliday
+                .builder()
+                .shopInfo(shop)
+                .holStartDate(dto.getStartDate())
+                .holEndDate(dto.getEndDate())
+                .isHolRepeat(dto.isHolRepeat())
+                .build();
+
+        /*빌드한 데이터 저장*/
+        ShopHoliday savedHol = shopHolidayRepository.save(hol);
+
+        /*Entity -> DTO 변환하여 반환*/
+        HolResDTO resDTO = modelMapper.map(savedHol, HolResDTO.class);
+
+        /*정기 휴무일 경우 메시지*/
+        if (dto.isHolRepeat()) {
+            resDTO.setDescription("정기 휴무일이 정상적으로 반영되었습니다.");
+        } else {
+            resDTO.setDescription("휴무일이 정상적으로 반영되었습니다.");
+        }
+
+        return modelMapper.map(savedHol, HolResDTO.class);
+    }
+
+    /*사용자가 접근하려는 날짜가 휴일인지 검증하는 메소드*/
+    public boolean isHoliday(Integer shopCode, Date dateToScan) {
+
+        /*1. 임시 휴일 확인*/
+        if (shopHolidayRepository.isTempHoliday(shopCode, dateToScan)) return true;
+
+        /*2. 정기 휴일 확인*/
+        List<ShopHoliday> repeatHols = shopHolidayRepository.findRegHoliday(shopCode, dateToScan);
+
+        /* 반환된 값이 비어있지 않을 때만 검증 */
+        if (!repeatHols.isEmpty()) {
+            /*java.time의 요일 계산 클래스*/
+            DayOfWeek day = dateToScan.toLocalDate().getDayOfWeek();
+            for (ShopHoliday hol : repeatHols) {
+                if (hol.getHolStartDate().toLocalDate().getDayOfWeek() == day) {
+                    return true;
+                }
+            }
+        }
+
+        /*3. 확인 메소드를 모두 통과한 경우 false = 휴일 아님 반환*/
+        return false;
+    }
+}

--- a/src/test/java/com/header/header/domain/shop/service/ShopHolidayServiceTests.java
+++ b/src/test/java/com/header/header/domain/shop/service/ShopHolidayServiceTests.java
@@ -1,10 +1,19 @@
 package com.header.header.domain.shop.service;
 
-import com.header.header.domain.shop.dto.CreateHolReqDTO;
+import com.header.header.domain.menu.entity.Menu;
+import com.header.header.domain.menu.entity.MenuCategory;
+import com.header.header.domain.menu.entity.MenuCategoryId;
+import com.header.header.domain.menu.repository.MenuCategoryRepository;
+import com.header.header.domain.menu.repository.MenuRepository;
+import com.header.header.domain.reservation.repository.UserReservationRepository;
+import com.header.header.domain.shop.dto.HolCreationDTO;
 import com.header.header.domain.shop.dto.HolResDTO;
+import com.header.header.domain.shop.dto.HolUpdateDTO;
 import com.header.header.domain.shop.entity.Shop;
 import com.header.header.domain.shop.entity.ShopCategory;
 import com.header.header.domain.shop.entity.ShopHoliday;
+import com.header.header.domain.shop.exception.ShopHolidayExceptionHandler;
+import com.header.header.domain.shop.projection.ShopHolidayInfo;
 import com.header.header.domain.shop.repository.ShopCategoryRepository;
 import com.header.header.domain.shop.repository.ShopHolidayRepository;
 import com.header.header.domain.shop.repository.ShopRepository;
@@ -13,10 +22,14 @@ import com.header.header.domain.user.repository.MainUserRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -32,11 +45,18 @@ public class ShopHolidayServiceTests {
     private ShopRepository shopRepository;
     @Autowired
     private ShopHolidayRepository shopHolidayRepository;
+    @Autowired
+    private MenuRepository menuRepository;
+    @Autowired
+    private UserReservationRepository userReservationRepository;
+    @Autowired
+    private MenuCategoryRepository menuCategoryRepository;
 
     private Integer testShopCode;
+    private Integer testMenuCategoryCode;
+    private Integer testMenuCode;
 
-    @BeforeEach
-    @Test
+    @Commit
     void setUp() {
 
         /*테스트용 유저*/
@@ -46,7 +66,7 @@ public class ShopHolidayServiceTests {
         ShopCategory category = shopCategoryRepository.findById(1).orElseThrow();
 
         /*테스트용 샵*/
-        Shop shop = Shop.builder()
+        Shop testShop = Shop.builder()
                 .shopName("기니기니")
                 .adminInfo(testUser)
                 .shopPhone("010-1111-1111")
@@ -59,13 +79,13 @@ public class ShopHolidayServiceTests {
                 .isActive(true)
                 .build();
 
-        shopRepository.save(shop);
+        shopRepository.save(testShop);
 
-        testShopCode = shop.getShopCode();
+        testShopCode = testShop.getShopCode();
 
         /*테스트용 일시 휴무*/
         ShopHoliday tempHoliday = ShopHoliday.builder()
-                .shopInfo(shop)
+                .shopInfo(testShop)
                 .holStartDate(new Date(2025, 7, 1))
                 .holEndDate(new Date(2025, 7, 10))
                 .isHolRepeat(false)
@@ -74,25 +94,70 @@ public class ShopHolidayServiceTests {
 
         /*테스트용 정기 휴무 (일요일)*/
         ShopHoliday regHoliday = ShopHoliday.builder()
-                .shopInfo(shop)
+                .shopInfo(testShop)
                 .holStartDate(new Date(2025, 7, 13))
                 .holEndDate(null)
                 .isHolRepeat(true)
                 .build();
         shopHolidayRepository.save(regHoliday);
 
+        /*테스트용 메뉴 카테고리 및 메뉴*/
+        testMenuCategoryCode = 5; // 두피케어
+
+        MenuCategoryId id
+                = new MenuCategoryId(testMenuCategoryCode, testShopCode);
+
+        // 수정된 코드
+        MenuCategory menuCategory = MenuCategory.builder()
+                .id(id)
+                .categoryName("기니피그 전용 메뉴")
+                .menuColor("#FFFFFF")
+                .isActive(true)
+                .build();
+        MenuCategory savedMenuCategory = menuCategoryRepository.save(menuCategory);
+
+        // 또는 명시적으로 재조회
+        MenuCategory managedMenuCategory = menuCategoryRepository.findById(id).orElseThrow();
+
+        Menu menu = Menu.builder()
+                .menuName("기니피기 손님용 특별케어")
+                .menuPrice(1000)
+                .estTime(300)
+                .isActive(true)
+                .menuCategory(managedMenuCategory)  // managed 상태의 엔티티 사용
+                .build();
+        Menu testMenu = menuRepository.save(menu);
+        Menu managedMenu = menuRepository.findById(testMenu.getMenuCode()).orElseThrow();
+
+/*        // 테스트용 예약
+        BossReservation reservation = BossReservation
+                .builder()
+                .userInfo(testUser)
+                .shopInfo(testShop)
+                .menuInfo(managedMenu)
+                .resvDate(new Date(2025, 8, 12)) //8월 화요일 = 화요일 시도하면 예외, 8월 12일 포함된 날짜 일시휴무 생성 시도하면 예외
+                .resvTime(new Time(14, 0, 0))
+                .userComment("ttt")
+                .resvState(ReservationState.APPROVE)
+                .build();
+
+        userReservationRepository.save(reservation);*/
+
     }
+
+    private final Integer SHOP_CODE = 1;
+    private final Integer HOL_CODE = 1;
 
     @Test
     @Order(1)
     @DisplayName("임시 휴일 생성하기")
     void createHoliday() {
         //given
-        CreateHolReqDTO dto = new CreateHolReqDTO();
-        dto.setShopCode(testShopCode);
+        HolCreationDTO dto = new HolCreationDTO();
+        dto.setShopCode(SHOP_CODE);
         dto.setStartDate(new Date(2025, 7, 1));
         dto.setEndDate(new Date(2025, 7, 10));
-        dto.setHolRepeat(false);
+        dto.setIsHolRepeat(false);
 
         //when
         HolResDTO resDTO = shopHolidayService.createShopHoliday(dto);
@@ -103,5 +168,157 @@ public class ShopHolidayServiceTests {
         assertNotNull(testHolCode);
         System.out.println(resDTO);
         System.out.println(testHolCode);
+    }
+
+    // 예약: 8/30 (토) 샵코드 1에 대해 있음
+    // Date modify :Date.valueOf("2025-09-30") format
+
+    @Test
+    @Order(2)
+    @DisplayName("예약 있는 날짜에 임시 휴일 생성 시도")
+    void createHolidayInReservedDate() {
+        //given (반복하지 않는 일시 휴일, 8/10 ~ 8/30)
+        HolCreationDTO dto = new HolCreationDTO();
+        dto.setShopCode(1);
+        dto.setStartDate(Date.valueOf(LocalDate.of(2025, 8, 10)));
+        dto.setEndDate(Date.valueOf(LocalDate.of(2025, 8, 30)));
+        dto.setIsHolRepeat(false);
+
+        //when and then
+        assertThrows(ShopHolidayExceptionHandler.class,
+                () -> shopHolidayService.createShopHoliday(dto));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("예약 있는 날짜에 정기 휴일 생성 시도")
+    void createRegHolidayInReservedDate() {
+        //given
+        HolCreationDTO dto = new HolCreationDTO();
+        dto.setShopCode(1);
+        dto.setStartDate(Date.valueOf(LocalDate.of(2025, 8, 2)));
+        dto.setEndDate(null);
+        dto.setIsHolRepeat(true);
+
+        //when and then
+        assertThrows(ShopHolidayExceptionHandler.class,
+                () -> shopHolidayService.createShopHoliday(dto));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("휴일 수정하기")
+    void testSuccessModify() {
+        // given
+        HolUpdateDTO dto = HolUpdateDTO.builder()
+                .shopHolCode(1)
+                .shopCode(1)
+                .startDate(Date.valueOf("2025-09-30"))
+                .endDate(Date.valueOf("2025-10-30"))
+                .isHolRepeat(false)
+                .build();
+
+        //when and then
+        HolResDTO resDto = shopHolidayService.updateShopHoliday(dto);
+        assertNotNull(resDto);
+        System.out.println(resDto);
+    }
+
+    // exception - reg, temp test
+    // read (whole, and specify ???, projection... easy)
+    // delete (physical) - easy...
+
+    @Test
+    @Order(5)
+    @DisplayName("예약 있는 날짜에 정기 휴일 변경 시도")
+    void testModifyWhenReservedDate() {
+        //given
+        HolUpdateDTO dto = HolUpdateDTO.builder()
+                .shopHolCode(HOL_CODE)
+                .shopCode(SHOP_CODE)
+                .startDate(Date.valueOf("2025-08-02")) // 화요일
+                .endDate(null)
+                .isHolRepeat(true)
+                .build();
+
+        //when and then
+        assertThrows(ShopHolidayExceptionHandler.class,
+                () -> shopHolidayService.updateShopHoliday(dto));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("예약 있는 날짜에 일시 휴일 변경 시도")
+    void testModifyTempWhenReservedDate() {
+        //given
+        HolUpdateDTO dto = HolUpdateDTO.builder()
+                .shopHolCode(HOL_CODE)
+                .shopCode(SHOP_CODE)
+                .startDate(Date.valueOf("2025-08-30"))
+                .endDate(Date.valueOf("2025-09-01"))
+                .isHolRepeat(false)
+                .build();
+
+        //when and then
+        assertThrows(ShopHolidayExceptionHandler.class,
+                () -> shopHolidayService.updateShopHoliday(dto));
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("샵이 가진 휴일 정보 불러오기")
+    void testReadShopHoliday() {
+        //given
+        Integer shopCode = 1;
+
+        //when and then
+        List<ShopHolidayInfo> hols
+                = shopHolidayService.getShopHolidayInfo(shopCode);
+
+        assertNotNull(hols);
+        hols.forEach(hol -> System.out.println(
+                hol.getHolStartDate() + " ~ " + hol.getHolEndDate()
+                + " / " + hol.getIsHolRepeat()
+        ));
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("휴일 정보 삭제 테스트")
+    @Transactional
+    void testDeleteHoliday() {
+        //given
+        ShopHoliday tempHoliday = ShopHoliday.builder()
+                .shopInfo(shopRepository.findById(SHOP_CODE).orElseThrow())
+                .holStartDate(new Date(2025, 7, 1))
+                .holEndDate(new Date(2025, 7, 10))
+                .isHolRepeat(false)
+                .build();
+        shopHolidayRepository.save(tempHoliday);
+        Integer shopHolCodeToDelete = tempHoliday.getShopHolCode();
+
+        //when and then
+        shopHolidayService.deleteShopHoliday(SHOP_CODE, shopHolCodeToDelete);
+        assertTrue(shopHolidayRepository.findById(shopHolCodeToDelete).isEmpty());
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("해당 샵이 가지지 않은 휴일 정보 삭제 시도")
+    @Transactional
+    void testDeleteWrongHoliday() {
+        //given
+        ShopHoliday tempHoliday = ShopHoliday.builder()
+                .shopInfo(shopRepository.findById(SHOP_CODE).orElseThrow())
+                .holStartDate(new Date(2025, 7, 1))
+                .holEndDate(new Date(2025, 7, 10))
+                .isHolRepeat(false)
+                .build();
+        shopHolidayRepository.save(tempHoliday);
+        Integer shopHolCodeToDelete = tempHoliday.getShopHolCode();
+
+        //when and then
+        assertThrows(ShopHolidayExceptionHandler.class,
+                () -> shopHolidayService.deleteShopHoliday(SHOP_CODE, 100000));
     }
 }

--- a/src/test/java/com/header/header/domain/shop/service/ShopHolidayServiceTests.java
+++ b/src/test/java/com/header/header/domain/shop/service/ShopHolidayServiceTests.java
@@ -1,0 +1,107 @@
+package com.header.header.domain.shop.service;
+
+import com.header.header.domain.shop.dto.CreateHolReqDTO;
+import com.header.header.domain.shop.dto.HolResDTO;
+import com.header.header.domain.shop.entity.Shop;
+import com.header.header.domain.shop.entity.ShopCategory;
+import com.header.header.domain.shop.entity.ShopHoliday;
+import com.header.header.domain.shop.repository.ShopCategoryRepository;
+import com.header.header.domain.shop.repository.ShopHolidayRepository;
+import com.header.header.domain.shop.repository.ShopRepository;
+import com.header.header.domain.user.entity.User;
+import com.header.header.domain.user.repository.MainUserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.sql.Date;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ShopHolidayServiceTests {
+
+    @Autowired
+    private ShopHolidayService shopHolidayService;
+    @Autowired
+    private MainUserRepository userRepository;
+    @Autowired
+    private ShopCategoryRepository shopCategoryRepository;
+    @Autowired
+    private ShopRepository shopRepository;
+    @Autowired
+    private ShopHolidayRepository shopHolidayRepository;
+
+    private Integer testShopCode;
+
+    @BeforeEach
+    @Test
+    void setUp() {
+
+        /*테스트용 유저*/
+        User testUser = userRepository.findById(1).orElseThrow();
+
+        /*테스트용 샵 카테고리*/
+        ShopCategory category = shopCategoryRepository.findById(1).orElseThrow();
+
+        /*테스트용 샵*/
+        Shop shop = Shop.builder()
+                .shopName("기니기니")
+                .adminInfo(testUser)
+                .shopPhone("010-1111-1111")
+                .shopLocation("서울시 송파구")
+                .shopLong(127.0276)
+                .shopLa(37.2979)
+                .categoryInfo(category)
+                .shopOpen("09:00")
+                .shopClose("18:00")
+                .isActive(true)
+                .build();
+
+        shopRepository.save(shop);
+
+        testShopCode = shop.getShopCode();
+
+        /*테스트용 일시 휴무*/
+        ShopHoliday tempHoliday = ShopHoliday.builder()
+                .shopInfo(shop)
+                .holStartDate(new Date(2025, 7, 1))
+                .holEndDate(new Date(2025, 7, 10))
+                .isHolRepeat(false)
+                .build();
+        shopHolidayRepository.save(tempHoliday);
+
+        /*테스트용 정기 휴무 (일요일)*/
+        ShopHoliday regHoliday = ShopHoliday.builder()
+                .shopInfo(shop)
+                .holStartDate(new Date(2025, 7, 13))
+                .holEndDate(null)
+                .isHolRepeat(true)
+                .build();
+        shopHolidayRepository.save(regHoliday);
+
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("임시 휴일 생성하기")
+    void createHoliday() {
+        //given
+        CreateHolReqDTO dto = new CreateHolReqDTO();
+        dto.setShopCode(testShopCode);
+        dto.setStartDate(new Date(2025, 7, 1));
+        dto.setEndDate(new Date(2025, 7, 10));
+        dto.setHolRepeat(false);
+
+        //when
+        HolResDTO resDTO = shopHolidayService.createShopHoliday(dto);
+        int testHolCode = resDTO.getShopHolCode();
+
+        //then
+        assertNotNull(resDTO);
+        assertNotNull(testHolCode);
+        System.out.println(resDTO);
+        System.out.println(testHolCode);
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

- 샵은 일시, 혹은 정기적 (요일) 타입의 휴일을 생성할 수 있습니다.
- 고객과 샵은 샵이 가진 휴일 정보를 볼 수 있습니다 (휴일 시작일, 종료일, 반복 여부(=정기휴일 여부))
- 샵은 자신의 휴일 정보를 수정할 수 있습니다. 
- 샵은 자신의 휴일 정보를 물리적으로 삭제할 수 있습니다.

## 스크린샷 (선택) 
<img width="522" height="275" alt="Screenshot 2025-07-15 at 10 33 08" src="https://github.com/user-attachments/assets/594ba226-c856-4688-9519-e3109a7485fa" />
 
