### PR TITLE
[FIX] User Reservation 예외 처리 개선 및 예약 가능 스케쥴 리스트 반환 기능 구현

### DIFF
--- a/src/main/java/com/header/header/domain/reservation/dto/UserResvAvailableScheduleDTO.java
+++ b/src/main/java/com/header/header/domain/reservation/dto/UserResvAvailableScheduleDTO.java
@@ -1,0 +1,26 @@
+package com.header.header.domain.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Setter
+// 가능한 시간을 생성자 형태로 담아주기 위해 사용
+@AllArgsConstructor
+public class UserResvAvailableScheduleDTO {
+    /* 프론트에 가능한 스케쥴만 스캔하여 보내주는 DTO */
+
+    // 한 날짜는 여러개의 가능한 시간이 존재함
+
+    /* 날짜만 다뤄야 하기 때문에, 혹시 모를 문제점을 방지하기 위해 LocalDate 사용
+    *  + LocalDate는 불변 객체로 스레드 안전성을 보장한다 */
+    private LocalDate targetDate;
+
+    // 현재 시간대 정보 필요해서 LocalTime 사용
+    private List<LocalTime> availableTimes;
+}

--- a/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
+++ b/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
@@ -16,7 +16,10 @@ public enum UserReservationErrorCode {
     USER_HAS_LEFT("USER_HAS_LEFT", "탈퇴한 사용자 정보입니다"),
     INPUT_DATE_WRONG("INPUT_DATE_WRONG", "조회 시작 날짜는 조회 종료 날짜보다 이전이어야 합니다."),
     SHOP_NOT_FOUND("SHOP_NOT_FOUND", "샵 정보를 찾을 수 없습니다."),
-    MENU_NOT_FOUND("MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다.");
+    MENU_NOT_FOUND("MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다."),
+    DATE_HAS_HOL("DATE_HAS_HOL", "선택하신 날짜는 샵 휴무일 입니다."),
+    SCHEDULE_ALREADY_TAKEN("SCHEDULE_ALREADY_TAKEN", "해당 시간은 이미 예약되었습니다. \n 다른 일정을 선택해 주세요."),
+    USER_SCHEDULE_UNAVAILABLE("USER_SCHEDULE_UNAVAILABLE", "해당 일정에 고객님의 다른 시술이 예정되어 있습니다. \n 다른 일정을 선택해 주세요.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
+++ b/src/main/java/com/header/header/domain/reservation/repository/UserReservationRepository.java
@@ -1,7 +1,6 @@
 package com.header.header.domain.reservation.repository;
 
 import com.header.header.domain.reservation.entity.BossReservation;
-import com.header.header.domain.reservation.enums.ReservationState;
 import com.header.header.domain.reservation.projection.UserReservationDetail;
 import com.header.header.domain.reservation.projection.UserReservationSummary;
 import org.apache.ibatis.annotations.Param;
@@ -9,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.sql.Date;
-import java.time.LocalDate;
+import java.sql.Time;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,5 +100,32 @@ public interface UserReservationRepository extends JpaRepository<BossReservation
             @Param("resvDate") Date resvDate
     );
 
+    /*예약 시도 날짜, 시간이 이미 예약상에 존재하는지 검증 - 예약 생성시 사용*/
+    @Query("""
+           SELECT COUNT (r) = 0
+           FROM BossReservation r
+           WHERE r.shopInfo.shopCode = :shopCode
+           AND r.resvDate = :resvDate
+           AND r.resvTime = :resvTime
+           """)
+    boolean isAvailableSchedule(
+            @Param("shopCode") Integer shopCode,
+            @Param("resvDate") Date resvDate,
+            @Param("resvTime") Time resvTime
+    );
 
+    /*해당 유저가 이미 그 날짜, 그 시간에 예약이 있는 경우,
+    * 같은 시간에 예약하는 것 및 노쇼 방어용 */
+    @Query("""
+          SELECT COUNT (r) > 0 
+          FROM BossReservation r
+          WHERE r.userInfo.userCode = :userCode
+          AND r.resvDate = :resvDate
+          AND r.resvTime = :resvTime
+          """)
+    boolean isUserHasReservationInThisSchedule(
+            @Param("userCode") Integer userCode,
+            @Param("resvDate") Date resvDate,
+            @Param("resvTime") Time resvTime
+    );
 }

--- a/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
+++ b/src/main/java/com/header/header/domain/reservation/service/UserReservationService.java
@@ -5,6 +5,7 @@ import com.header.header.domain.menu.entity.Menu;
 import com.header.header.domain.menu.repository.MenuRepository;
 import com.header.header.domain.reservation.dto.UserReservationDTO;
 import com.header.header.domain.reservation.dto.UserReservationSearchConditionDTO;
+import com.header.header.domain.reservation.dto.UserResvAvailableScheduleDTO;
 import com.header.header.domain.reservation.entity.BossReservation;
 import com.header.header.domain.reservation.enums.ReservationState;
 import com.header.header.domain.reservation.enums.UserReservationErrorCode;
@@ -17,13 +18,17 @@ import com.header.header.domain.shop.entity.ShopHoliday;
 import com.header.header.domain.shop.repository.ShopHolidayRepository;
 import com.header.header.domain.shop.repository.ShopRepository;
 import com.header.header.domain.user.entity.User;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date; // util.Date -> 날짜 및 시간 (1970 기준 밀리초 포함), 오래된 범용 타입, 사용 지양
+import java.sql.Time;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,7 +46,7 @@ public class UserReservationService {
     /*사용자가 자신의 예약 내역을 상세 조회할 경우*/
     public Optional<UserReservationDetail> readDetailByUserCodeAndResvCode(Integer userCode, Integer resvCode) {
 
-            /*사용자 정보가 존재하지 않을 경우 예외*/
+        /*사용자 정보가 존재하지 않을 경우 예외*/
         User user = userRepository.findById(userCode)
                 .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.USER_NOT_FOUND));
 
@@ -60,8 +65,7 @@ public class UserReservationService {
 
     /*사용자가 자신이 예약한 내역들의 목록을 조회할 경우*/
     public List<UserReservationSummary> findResvSummaryByUserCode(
-            UserReservationSearchConditionDTO conditionDTO)
-    {
+            UserReservationSearchConditionDTO conditionDTO) {
         /*유효성 체크가 된 데이터들 한개씩 꺼내오기*/
         Integer userCode = conditionDTO.getUserCode();
         Date startDate = conditionDTO.getStartDate();
@@ -75,7 +79,6 @@ public class UserReservationService {
                 throw new UserReservationExceptionHandler(UserReservationErrorCode.INPUT_DATE_WRONG);
             }
         }
-
 
         /*사용자 정보가 존재하지 않을 경우 예외*/
         User user = userRepository.findById(userCode)
@@ -94,10 +97,27 @@ public class UserReservationService {
     public Optional<UserReservationDetail> createReservation(
             UserReservationDTO dto
     ) {
-        /* 엔티티 유효성 검사*/
+        /* DTO 에서 어노테이션 유효성 검사 끝낸 값들 가져오기*/
         Integer userCode = dto.getUserCode();
         Integer shopCode = dto.getShopCode();
         Integer menuCode = dto.getMenuCode();
+        Date resvDate = dto.getResvDate();
+        Time resvTime = dto.getResvTime();
+
+        // 예약 시도 날짜가 샵 휴무일인 경우 예외
+        if (isHoliday(shopCode, resvDate)) {
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.DATE_HAS_HOL);
+        }
+
+        // 예약 시도 날짜가 이미 예약되어 있을 경우 예외
+        if (!userReservationRepository.isAvailableSchedule(shopCode, resvDate, resvTime)) {
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.SCHEDULE_ALREADY_TAKEN);
+        }
+
+        // 고객의 일정에 해당 날짜, 시간의 예약이 있을 경우 (노쇼 방지)
+        if(userReservationRepository.isUserHasReservationInThisSchedule(userCode, resvDate, resvTime)) {
+            throw new UserReservationExceptionHandler(UserReservationErrorCode.USER_SCHEDULE_UNAVAILABLE);
+        }
 
         /*유효하지 않은 사용자 정보일 경우 예외*/
         User user = userRepository.findById(userCode)
@@ -120,8 +140,8 @@ public class UserReservationService {
                 .userInfo(user)
                 .shopInfo(shop)
                 .menuInfo(menu)
-                .resvDate(dto.getResvDate())
-                .resvTime(dto.getResvTime())
+                .resvDate(resvDate)
+                .resvTime(resvTime)
                 .userComment(dto.getUserComment())
                 .resvState(ReservationState.APPROVE)
                 // 예약을 생성할 경우 기본값은 "예약확정"
@@ -192,6 +212,76 @@ public class UserReservationService {
 
         /* 휴일 아님 false 반환*/
         return false;
+    }
+
+    /* 프론트에 예약 가능한 날짜와 시간을 모아서 보내주는 용도 */
+    // @Param: shopCode, dateRangeToGet (for 문에서 스캔할 날짜의 개수... 일단 한 달 줄 예정)
+    @Transactional(readOnly = true)
+    // 영속성 컨텍스트에게 읽기 전용이라는 것을 명시해 성능 향상. 날짜별로 for문을 돌려서 쿼리가 많이 실행되기 때문에 방어용도로 사용
+    public List<UserResvAvailableScheduleDTO> getAvailableSchedule(Integer shopCode, int dateRangeToGet) {
+
+        //존재하지 않는 샵일 경우 예외
+        Shop shop = shopRepository.findById(shopCode)
+                .orElseThrow(() -> new UserReservationExceptionHandler(UserReservationErrorCode.SHOP_NOT_FOUND));
+
+        List<UserResvAvailableScheduleDTO> result = new ArrayList<>();
+
+        /* 데이터 검증 및 추가 순서
+          @Param: shopOpen, shopClose, dateRangeToGet
+        * 1) 현재를 기준으로 미래 한 달(dateRangeToGet) 까지 스캔해서 휴일이 없는 날짜
+             - 현재 날짜+for문 돌리는 날짜, 샵 코드 필요
+             - if(true) continue (휴일이 있다면, 현재 반복문 중단하고 다시 돌아가 조건에 맞으면 다음 단계 시행)
+
+          2) 1 통과한 날짜들의 시간 한 시간 단위로 쪼개기
+
+          3) 2 통과한 날짜, 시간 중 예약자가 없는 날짜와 시간
+             - 1에서 통과한 날짜, 쪼개진 시간 필요
+             - if (isAvailableSchedule == true) 인 경우만 list 추가
+        * */
+
+        for (int i = 0; i < dateRangeToGet; i++) {
+
+            //for 문의 기준이 될 targetDate
+            LocalDate targetDate = LocalDate.now().plusDays(i);
+
+            // targetDate가 휴일인 경우 continue로 건너뛰고 다음 날짜 검증
+            if (isHoliday(shopCode, Date.valueOf(targetDate))) continue;
+
+            // 예약 가능한 시간들을 담을 list
+            List<LocalTime> availableTimes = new ArrayList<>();
+
+            /* String 타입인 샵 운영 시간 가져오기,
+                shopOpen : 더해줄 시간 시작점
+                shopClose : 시간 더하기 종료지점
+                for문 내부에서 LocalDate.now(), plusMinutes() 사용하기 위해 LocalTime 사용 */
+            LocalTime time = LocalTime.parse(shop.getShopOpen());
+            LocalTime shopClose = LocalTime.parse(shop.getShopClose());
+
+            // time 시간이 close 시간보다 이전일 동안
+            while (time.isBefore(shopClose)) {
+
+                // 예약 가능한 시간인지 검증
+                boolean isAvailableSchedule = userReservationRepository
+                        .isAvailableSchedule(shopCode, Date.valueOf(targetDate), Time.valueOf(time));
+
+                if (isAvailableSchedule) {
+                    // 예약 가능한 시간인 경우, 가능한 시간 list에 하나씩 더해준다
+                    availableTimes.add(time);
+                }
+                // 예약은 한 시간 단위로 받는다
+                time = time.plusMinutes(60);
+
+            }
+                // while 문을 빠져나왔을 때
+                // 가능한 시간을 담은 리스트가 비어있지 않을 때만 UserResvAvailableScheduleDTO 객체 생성
+                if (!availableTimes.isEmpty()) {
+                    result.add(new UserResvAvailableScheduleDTO(targetDate, availableTimes));
+                }
+
+        }
+
+        // for문 빠져나온 result 저장
+        return result;
     }
 
 }

--- a/src/main/java/com/header/header/domain/shop/repository/ShopHolidayRepository.java
+++ b/src/main/java/com/header/header/domain/shop/repository/ShopHolidayRepository.java
@@ -55,7 +55,7 @@ public interface ShopHolidayRepository extends JpaRepository<ShopHoliday, Intege
             """)
     List<ShopHolidayInfo> getShopHolidayInfo(@Param("shopCode") Integer shopCode, @Param("today") Date today);
 
-    // 그 샵에 해당하는 휴일 정보가 맞는지 검증 (삭제시 사용)
+    // 그 샵에 해당하는 휴일 정보가 맞는지 검증 (휴일 삭제시 사용)
     @Query("""
            SELECT COUNT(h) = 1 
            FROM ShopHoliday h


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

- Shop Holiday 테이블 생성에 맞춰 User Reservation 예외 처리를 개선했습니다. 
     - 가게 임시 휴무인 날짜에 예약 시도
     - 가게 정기 휴무 요일에 예약 시도
     - 이미 다른 사람에 의해 예약된 날짜에 예약 시도
     - 예약을 시도하는 유저가 그 날짜, 시간에 다른 예약이 있는 경우 (노쇼 방지)
    
- 이외) 휴무일, 예약된 날짜를 필터링 하여 한 달 단위로 예약 가능한 날짜와 시간을 모아서 리스트 형태로 반환하는 리스트 기능을 구현했습니다.

## 스크린샷 (선택)

<img width="518" height="426" alt="Screenshot 2025-07-15 at 13 55 29" src="https://github.com/user-attachments/assets/a162a7f2-52b0-4dad-989b-ef68a3da0b9c" />

closed #81 