### PR TITLE
[BUG] #91 bug 프론트앤드 api 요청시 401 unauthorized 해결

### DIFF
--- a/src/main/java/com/header/header/auth/config/SecurityConfig.java
+++ b/src/main/java/com/header/header/auth/config/SecurityConfig.java
@@ -1,9 +1,17 @@
 package com.header.header.auth.config;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 public class SecurityConfig {
@@ -11,5 +19,33 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();  //pwd 암호화에 가장 많이 사용되는 알고리즘, BCryptPasswordEncoder
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(withDefaults())  // CORS 설정은 그대로 유지
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // ✅ 모든 요청 허용
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable); // 필요시 비활성화
+
+        return http.build();
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(@NotNull CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [X] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 
## 💊버그 해결
- SpringSecurity의 FilterChain을 커스터마이징하여 일시적으로 CORS 및 인증 오류를 해결하였습니다.
해당 설정은 "모든 요청을 허용" 하는 설정이기 때문에 보안상 좋지 않습니다.

현재 로그인 토큰 기능이 구현되어있지않아 인증기능을 키게 되면 프론트에서 토큰을 보낼 수 없어 인증이 불가하기 때문에
다음과 같이 설정한 점 참고부탁드립니다.

아래의 필터 체인은 JWT 토큰 기반 로그인 구현 이후 반드시 수정되어야 합니다.
 
``` java
@Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .cors(withDefaults())  // CORS 설정은 그대로 유지
                .authorizeHttpRequests(auth -> auth
                        .anyRequest().permitAll() // ✅ 모든 요청 허용
                )
                .csrf(AbstractHttpConfigurer::disable)
                .formLogin(AbstractHttpConfigurer::disable)
                .httpBasic(AbstractHttpConfigurer::disable); // 필요시 비활성화

        return http.build();
    }
```

## 스크린샷 (선택)
<img width="2487" height="1374" alt="image" src="https://github.com/user-attachments/assets/12227273-40f2-42cd-b080-29fd47182642" />
 
close #91 