### PR TITLE
[FEATURE] #75 send message service controller mapping

### DIFF
--- a/src/main/java/com/header/header/domain/message/controller/MessageController.java
+++ b/src/main/java/com/header/header/domain/message/controller/MessageController.java
@@ -1,0 +1,34 @@
+package com.header.header.domain.message.controller;
+
+import com.header.header.common.controller.MyShopBaseController;
+import com.header.header.common.dto.response.ApiResponse;
+import com.header.header.domain.message.dto.MessageRequest;
+import com.header.header.domain.message.dto.MessageResponse;
+import com.header.header.domain.message.service.MessageSendFacadeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MessageController extends MyShopBaseController {
+
+    private final MessageSendFacadeService messageSendFacadeService;
+
+    @PostMapping("/messages")
+    public ResponseEntity<ApiResponse<MessageResponse>> sendMessage(
+            @PathVariable Integer shopId,
+            @RequestBody MessageRequest requestBody)
+    {
+        MessageResponse messageResponse  = null;
+
+        if(!requestBody.getIsScheduled()){
+            messageResponse =  messageSendFacadeService.sendImmediateMessage(requestBody);
+        }// todo. 예약 발송일 경우.
+
+        return ResponseEntity.ok(ApiResponse.success(messageResponse));
+    }
+}

--- a/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
+++ b/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
-
+/* Service에서 사용하는 메세지 DTO 입니다. */
 @Data
 @Builder
 public class MessageDTO {
@@ -20,9 +20,7 @@ public class MessageDTO {
     @NotBlank(message = "제목은 필수 입니다.")
     private String subject;
 
-    private Integer templateCode; // 필수 X
-
     @NotBlank(message = "메시지 내용은 필수입니다")
-    @Size(max = 2000, message = "메시지는 2000자 이하여야 합니다")
+    @Size(max = 1000, message = "메시지는 1000자 이하여야 합니다")
     private String text;
 }

--- a/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
+++ b/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
@@ -4,12 +4,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
+
 /* Service에서 사용하는 메세지 DTO 입니다. */
 @Data
 @Builder
 public class MessageDTO {
     @NotBlank(message = "유저 코드는 필수입니다")
-    private Integer to;
+    private List<Integer> to;
 
     @NotBlank(message = "발신 샵 코드는 필수입니다")
     private Integer from;

--- a/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
+++ b/src/main/java/com/header/header/domain/message/dto/MessageDTO.java
@@ -1,14 +1,13 @@
 package com.header.header.domain.message.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class MessageRequest {
+public class MessageDTO {
     @NotBlank(message = "유저 코드는 필수입니다")
     private Integer to;
 

--- a/src/main/java/com/header/header/domain/message/dto/MessageRequest.java
+++ b/src/main/java/com/header/header/domain/message/dto/MessageRequest.java
@@ -1,0 +1,38 @@
+package com.header.header.domain.message.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageRequest {
+
+    @NotBlank(message = "메시지 내용은 필수입니다.")
+    @Size(max = 1000, message = "메시지는 1000자 이내로 작성해주세요.")
+    private String messageContent;
+
+    @NotEmpty(message = "수신자를 선택해주세요.")
+    @Size(max = 100, message = "한 번에 최대 100명까지 발송 가능합니다.")
+    private List<Integer> clientCodes; // Front에서 요청을 받을 때는 Client 코드로 요청을 받는다.
+
+    @NotNull(message = "발신 샵 코드는 필수입니다")
+    private Integer shopCode;
+
+    @NotBlank(message = "제목은 필수 입니다.")
+    private String subject;        // 메시지 제목
+
+    private Boolean isScheduled;        // 예약 발송 여부
+    private LocalDateTime scheduledDateTime; // 예약 발송 시간
+
+}

--- a/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
@@ -50,7 +50,6 @@ public class MessageAsyncService {
         // batch 저장
         MessageSendBatchDTO batchDTO = MessageSendBatchDTO.builder()
                 .shopCode(request.getFrom())
-                .templateCode(request.getTemplateCode())
                 .sendType(request.getSendType())
                 .subject(request.getSubject())
                 .build();

--- a/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
@@ -1,6 +1,6 @@
 package com.header.header.domain.message.service;
 
-import com.header.header.domain.message.dto.MessageRequest;
+import com.header.header.domain.message.dto.MessageDTO;
 import com.header.header.domain.message.dto.MessageResponse;
 import com.header.header.domain.message.dto.MessageSendBatchDTO;
 import com.header.header.domain.message.dto.ShopMessageHistoryDTO;
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -30,7 +28,7 @@ public class MessageAsyncService {
     /**
      * 즉시 응답 + 백그라운드 처리\
      */
-    public MessageResponse sendMessageAsync(MessageRequest request){
+    public MessageResponse sendMessageAsync(MessageDTO request){
 
         String taskId = generateTaskId();
         log.info("📩 [{}] 메시지 요청 접수 - UserCode: {}", taskId, request.getTo());
@@ -48,7 +46,7 @@ public class MessageAsyncService {
         return response;
     }
 
-    private ShopMessageHistory saveAsPending(MessageRequest request){
+    private ShopMessageHistory saveAsPending(MessageDTO request){
         // batch 저장
         MessageSendBatchDTO batchDTO = MessageSendBatchDTO.builder()
                 .shopCode(request.getFrom())
@@ -75,7 +73,7 @@ public class MessageAsyncService {
      */
     @Async("smsExecutor")
     public void processMessageAsync(ShopMessageHistory history,
-                                    MessageRequest request,
+                                    MessageDTO request,
                                     String taskId) {
 
         log.info("🔄 [{}] 백그라운드 처리 시작 - Thread: {}",

--- a/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageAsyncService.java
@@ -28,20 +28,19 @@ public class MessageAsyncService {
     private final UserService userService;
 
     /**
-     * 즉시 응답 + 백그라운드 처리\
+     * 즉시 응답 + 백그라운드 처리
      */
     public MessageResponse sendMessageAsync(MessageDTO request){
 
         String taskId = generateTaskId();
-        log.info("📩 [{}] 메시지 요청 접수 - UserCode: {}", taskId, request.getTo());
+        log.info("📩 [{}] 메시지 요청 접수 - UserCode 수: {}", taskId, request.getTo().size());
 
-        // 1. DB에 PENDING으로 저장
-        // batch 저장
+        // 1. batch DB에 저장
         MessageSendBatchDTO batchDTO = MessageSendBatchDTO.builder()
                 .shopCode(request.getFrom())
                 .sendType(request.getSendType())
                 .subject(request.getSubject())
-                .totalCount(request.getTo().size()) // 수신자 리스트 개수 카운트
+                .totalCount(request.getTo().size())
                 .successCount(0)
                 .failCount(0)
                 .build();
@@ -52,28 +51,25 @@ public class MessageAsyncService {
         List<ShopMessageHistory> historyList = new ArrayList<>();
 
         for(Integer userCode : request.getTo()){
-            historyList.add(saveAsPending(userCode,request.getText(),createdBatchDTO));
+            historyList.add(saveAsPending(userCode, request.getText(), createdBatchDTO));
         }
-
 
         // 3. PENDING으로 응답
         MessageResponse response = new MessageResponse(MessageStatus.PENDING.toString());
 
-        // 4. 백그라운드에서 비동기 처리
-        for(ShopMessageHistory history : historyList){
-            processMessageAsync(history, request, taskId);
-        }
-        log.info("⚡ [{}] PENDING 응답 즉시 반환", taskId);
+        // 4. ✅ 단일 비동기 작업으로 모든 메시지 처리 (배치 처리)
+        processAllMessagesAsync(historyList, request, taskId, createdBatchDTO.getBatchCode());
 
+        log.info("⚡ [{}] PENDING 응답 즉시 반환", taskId);
         return response;
     }
 
-    private ShopMessageHistory saveAsPending(Integer userCode, String Contents,MessageSendBatchDTO batchDTO){
+    private ShopMessageHistory saveAsPending(Integer userCode, String contents, MessageSendBatchDTO batchDTO){
 
         ShopMessageHistoryDTO historyDTO = ShopMessageHistoryDTO.builder()
                 .batchCode(batchDTO.getBatchCode())
                 .userCode(userCode)
-                .msgContent(Contents)
+                .msgContent(contents)
                 .sendStatus(MessageStatus.PENDING.toString())
                 .build();
 
@@ -81,25 +77,70 @@ public class MessageAsyncService {
     }
 
     /**
-     * 백그라운드에서 실제 SMS 전송 (@Async로 비동기 처리)
+     * 배치로 모든 메시지 처리 (단일 스레드에서 순차 처리)
      */
-    @Async("smsExecutor")
-    public void processMessageAsync(ShopMessageHistory history,
-                                    MessageDTO request,
-                                    String taskId) {
+    @Async("messageTaskExecutor")
+    public void processAllMessagesAsync(List<ShopMessageHistory> historyList,
+                                        MessageDTO request,
+                                        String taskId,
+                                        Integer batchCode){
+        log.info("📦 [{}] 전체 메시지 처리 시작 - 총 {}건", taskId, historyList.size());
 
-        log.info("🔄 [{}] 백그라운드 처리 시작 - Thread: {}",
-                taskId, Thread.currentThread().getName());
+        int successCount = 0;
+        int failCount = 0;
 
+        for(ShopMessageHistory history : historyList) {
+            try {
+                // SMS 전송 시도
+                sendSingleMessage(history, request, taskId);
+
+                // 성공 처리
+                successCount++;
+                updateMessageStatus(history, taskId, MessageStatus.SUCCESS, null);
+
+                // API 제한 방지를 위한 딜레이
+                if((successCount + failCount) % 10 == 0) {
+                    Thread.sleep(200); // 10건마다 0.2초 대기
+                }
+
+            } catch (Exception e) {
+                // 실패 처리
+                failCount++;
+                log.error("[{}] 메시지 전송 실패 - UserCode: {}, Error: {}",
+                        taskId, history.getUserCode(), e.getMessage());
+                updateMessageStatus(history, taskId, MessageStatus.FAIL, e);
+            }
+        }
+
+        // 배치 결과 업데이트
+        updateBatchResult(request.getFrom(), batchCode, successCount, failCount, taskId);
+
+        log.info("✅ [{}] 전체 처리 완료 - 성공: {}건, 실패: {}건", taskId, successCount, failCount);
+    }
+
+    /**
+     * 단일 메시지 전송 (Exception 발생 시 throws)
+     */
+    private void sendSingleMessage(ShopMessageHistory history,
+                                   MessageDTO request,
+                                   String taskId) throws Exception {
+
+        log.debug("🔄 [{}] 메시지 처리 시작 - UserCode: {}, Thread: {}",
+                taskId, history.getUserCode(), Thread.currentThread().getName());
+
+        // 1. 전화번호 조회
+        String phoneNumber = userService.getPhoneByUserCode(history.getUserCode());
+        if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+            throw new RuntimeException("전화번호를 찾을 수 없습니다: UserCode=" + history.getUserCode());
+        }
+
+        log.debug("📞 [{}] 전화번호 조회 완료: {}", taskId, phoneNumber);
+
+        // 2. 메시지 타입 결정 (SMS vs LMS)
+        boolean isLms = history.getMsgContent().length() > 90;
+
+        // 3. CoolSMS SDK로 실제 전송
         try {
-            // 1. 전화번호 조회
-            String phoneNumber = userService.getPhoneByUserCode(history.getUserCode());
-            log.info("📞 [{}] 전화번호 조회 완료: {}", taskId, phoneNumber);
-
-            // 2. 메시지 타입 결정 (SMS vs LMS)
-            boolean isLms = history.getMsgContent().length() > 90;
-
-            // 3. CoolSMS SDK로 실제 전송
             if (isLms) {
                 coolSmsService.sendLms(
                         "010-3908-5624",  // 발신번호 (테스트용)
@@ -115,40 +156,79 @@ public class MessageAsyncService {
                 );
             }
 
-            // 4. 성공 처리
-            handleSuccess(history, request.getFrom(), history.getBatchCode(),taskId);
+            log.debug("📤 [{}] SMS 전송 API 호출 완료 - UserCode: {}", taskId, history.getUserCode());
 
         } catch (Exception e) {
-            // 5. 실패 처리
-            handleFailure(history,request.getFrom(),  history.getBatchCode(),e, taskId);
+            throw new RuntimeException("SMS 전송 실패: " + e.getMessage(), e);
         }
     }
-    private void handleSuccess(ShopMessageHistory history, Integer shopCode, Integer batchCode, String taskId) {
+
+    /**
+     * 메시지 상태 업데이트
+     */
+    private void updateMessageStatus(ShopMessageHistory history, String taskId, MessageStatus status, Exception error){
+        if(MessageStatus.SUCCESS == status){
+            handleSuccess(history, taskId);
+        } else {
+            handleFailure(history, taskId, error);
+        }
+    }
+
+    /**
+     * 성공 처리
+     */
+    private void handleSuccess(ShopMessageHistory history, String taskId) {
         try {
-            log.info("✅ [{}] SMS 전송 성공", taskId);
-
-            shopMessageHistoryService.updateMessageStatus(history.getHistoryCode(),null);
-            messageSendBatchService.updateMessageBatchResults(shopCode, batchCode, true);// batch 성공 카운트 업데이트
+            log.debug("✅ [{}] SMS 전송 성공 - UserCode: {}", taskId, history.getUserCode());
+            shopMessageHistoryService.updateMessageStatus(history.getHistoryCode(), null);
 
         } catch (Exception e) {
-            log.error("[{}] 성공 처리 중 오류", taskId, e);
+            log.error("[{}] 성공 처리 중 오류 - UserCode: {}", taskId, history.getUserCode(), e);
         }
     }
 
-    private void handleFailure(ShopMessageHistory history, Integer shopCode,Integer batchCode, Exception error, String taskId) {
+    /**
+     * 실패 처리
+     */
+    private void handleFailure(ShopMessageHistory history, String taskId, Exception error) {
         try {
-            log.error("❌ [{}] SMS 전송 실패 - Error: {}", taskId, error.getMessage());
+            String errorMessage = error != null ? error.getMessage() : "알 수 없는 오류";
+            log.error("❌ [{}] SMS 전송 실패 - UserCode: {}, Error: {}",
+                    taskId, history.getUserCode(), errorMessage);
 
-            shopMessageHistoryService.updateMessageStatus(history.getHistoryCode(),error.getMessage());
-            messageSendBatchService.updateMessageBatchResults(shopCode, batchCode, false); // batch 실패 카운트 업데이트
-            
+            shopMessageHistoryService.updateMessageStatus(history.getHistoryCode(), errorMessage);
+
         } catch (Exception e) {
-            log.error("[{}] 실패 처리 중 오류", taskId, e);
+            log.error("[{}] 실패 처리 중 오류 - UserCode: {}", taskId, history.getUserCode(), e);
         }
     }
 
+    /**
+     * 배치 결과 업데이트
+     */
+    private void updateBatchResult(Integer shopCode, Integer batchCode, int successCount, int failCount, String taskId) {
+        try {
+            // 성공한 건수만큼 업데이트
+            for(int i = 0; i < successCount; i++) {
+                messageSendBatchService.updateMessageBatchResults(shopCode, batchCode, true);
+            }
+
+            // 실패한 건수만큼 업데이트
+            for(int i = 0; i < failCount; i++) {
+                messageSendBatchService.updateMessageBatchResults(shopCode, batchCode, false);
+            }
+
+            log.info("📊 [{}] 배치 결과 업데이트 완료 - 성공: {}, 실패: {}", taskId, successCount, failCount);
+
+        } catch (Exception e) {
+            log.error("[{}] 배치 결과 업데이트 중 오류", taskId, e);
+        }
+    }
+
+    /**
+     * 작업 ID 생성
+     */
     private String generateTaskId() {
         return UUID.randomUUID().toString().substring(0, 8);
     }
-
 }

--- a/src/main/java/com/header/header/domain/message/service/MessageSendBatchService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageSendBatchService.java
@@ -87,11 +87,10 @@ public class MessageSendBatchService {
      * INDEX 사용을 위해 샵 코드, 배치 코드를 둘 다 사용해서 조회
      * @param shopCode 샵 코드
      * @param batchCode 배치 코드
-     * @param successCount 성공 카운트
-     * @param failCount 실패 카운트
+     * @param result ( true = 성공, false = 실패 )
      * */
     @Transactional
-    protected MessageSendBatchDTO updateMessageBatchResults(Integer shopCode, Integer batchCode,int successCount, int failCount){
+    protected MessageSendBatchDTO updateMessageBatchResults(Integer shopCode, Integer batchCode, boolean result){
         if (shopCode == null || batchCode == null) {
             throw new IllegalArgumentException("shopCode와 batchCode는 필수입니다.");
         }
@@ -99,9 +98,15 @@ public class MessageSendBatchService {
         MessageSendBatch foundMessageBatch = messageSendBatchRepository.findByShopCodeAndBatchCode(shopCode, batchCode)
                 .orElseThrow(() -> InvalidBatchException.invalidBatchCode("존재하지 않는 배치 코드 입니다."));
 
-
+        Integer successCount = foundMessageBatch.getSuccessCount();
+        Integer failCount = foundMessageBatch.getFailCount();
         // 결과 업데이트
-        foundMessageBatch.updateBatchResultsCount(successCount, failCount);
+        if(result){
+            foundMessageBatch.updateBatchResultsCount( successCount+ 1, failCount);
+        }
+        else{
+            foundMessageBatch.updateBatchResultsCount( successCount, failCount + 1);
+        }
 
         return modelMapper.map(foundMessageBatch, MessageSendBatchDTO.class);
     }

--- a/src/main/java/com/header/header/domain/message/service/MessageSendFacadeService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageSendFacadeService.java
@@ -1,0 +1,47 @@
+package com.header.header.domain.message.service;
+
+import com.header.header.domain.message.dto.MessageDTO;
+import com.header.header.domain.message.dto.MessageRequest;
+import com.header.header.domain.message.dto.MessageResponse;
+import com.header.header.domain.visitors.service.VisitorsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageSendFacadeService {
+
+    private final MessageAsyncService messageAsyncService;
+    private final VisitorsService visitorsService;
+
+    /**
+     * 즉시 발송 메세지 FacadeService 메서드
+     * @param request Client 요청 DTO
+     * @return MessageResponse
+     */
+    public MessageResponse sendImmediateMessage(MessageRequest request){
+
+        /* 템플릿이든 직접 작성이든 messageContent로 포맷되서 들어온다. : 자동 메세지가 아닐  경우 */
+        List<Integer> userCodeList = new ArrayList<>();
+
+        /*1. UserCode를 ClientCode로 바꾼다.*/
+        for(Integer clientCode : request.getClientCodes()){
+            userCodeList.add(visitorsService.getUserCodeByClientCode(clientCode));
+        }
+
+        /*2. Service를 위한 MessageDTO를 만든다. */
+        MessageDTO messageDTO = MessageDTO.builder()
+                .to(userCodeList)
+                .from(request.getShopCode())
+                .sendType(userCodeList.size() > 1 ? "GROUP" :"INDIVIDUAL" ) // 2명 이상이면 그룹발송
+                .subject(request.getSubject())
+                .text(request.getMessageContent())
+                .build();
+
+        /*3. MessageAsyncService에서 메서드 호출*/
+        return messageAsyncService.sendMessageAsync(messageDTO);
+    }
+}

--- a/src/main/java/com/header/header/domain/visitors/repository/VisitorsRepository.java
+++ b/src/main/java/com/header/header/domain/visitors/repository/VisitorsRepository.java
@@ -27,7 +27,7 @@ public interface VisitorsRepository extends JpaRepository<Visitors,Integer> {
             "WHERE v.shopCode = :shopCode " +
             "AND v.isActive = true")
     List<VisitorWithUserInfoView> findVisitorWithUserInfoByShopCode(@Param("shopCode") Integer shopCode);
-    
+
     // (2) 방문 및 결제 통계 및 마지막 방문일 리스트 조회
     @Query("SELECT r.userCode as userCode, " +
             "       COUNT(*) as visitCount, " +
@@ -68,4 +68,8 @@ public interface VisitorsRepository extends JpaRepository<Visitors,Integer> {
     
     // (5) clientCode로 샵 회원 조회
     Optional<Visitors> findByClientCode(Integer clientCode);
+
+    @Query("SELECT v.userCode FROM Visitors v WHERE v.clientCode = :clientCode")
+    Optional<Integer> findUserCodeByClientCode(@Param("clientCode") Integer clientCode);
+
 }

--- a/src/main/java/com/header/header/domain/visitors/service/VisitorsService.java
+++ b/src/main/java/com/header/header/domain/visitors/service/VisitorsService.java
@@ -80,6 +80,14 @@ public class VisitorsService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * clientCode를 통해 대치되는 userCode를 조회.
+     * @param clientCode 클라이언트 코드
+     * @return Integer userCode
+     */
+    public Integer getUserCodeByClientCode(Integer clientCode){
+        return visitorsRepository.findUserCodeByClientCode(clientCode).orElseThrow();
+    }
 
     /**
      * 샵 회원 히스토리 리스트 조회

--- a/src/test/java/com/header/header/domain/message/service/MessageAsyncServiceTest.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageAsyncServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.sql.Timestamp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -45,7 +46,7 @@ class MessageAsyncServiceTest {
     void setUp() {
         // 테스트 데이터 준비
         testRequest = MessageDTO.builder()
-                .to(1)  // userCode
+                .to(list(1))  // userCode
                 .from(2)
                 .sendType("INDIVIDUAL")
                 .subject("테스트 제목")

--- a/src/test/java/com/header/header/domain/message/service/MessageAsyncServiceTest.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageAsyncServiceTest.java
@@ -1,6 +1,6 @@
 package com.header.header.domain.message.service;
 
-import com.header.header.domain.message.dto.MessageRequest;
+import com.header.header.domain.message.dto.MessageDTO;
 import com.header.header.domain.message.dto.MessageResponse;
 import com.header.header.domain.message.dto.ShopMessageHistoryDTO;
 import com.header.header.domain.message.entity.ShopMessageHistory;
@@ -37,14 +37,14 @@ class MessageAsyncServiceTest {
     @InjectMocks
     private MessageAsyncService messageAsyncService;
 
-    private MessageRequest testRequest;
+    private MessageDTO testRequest;
     private ShopMessageHistory mockHistoryEntity;  // Entity (Service에서 반환)
     private ShopMessageHistoryDTO mockHistoryDTO;  // DTO (테스트용)
 
     @BeforeEach
     void setUp() {
         // 테스트 데이터 준비
-        testRequest = MessageRequest.builder()
+        testRequest = MessageDTO.builder()
                 .to(1)  // userCode
                 .from(2)
                 .sendType("INDIVIDUAL")
@@ -252,7 +252,7 @@ class MessageAsyncServiceTest {
 
         // When - 리플렉션으로 private 메서드 테스트
         java.lang.reflect.Method method = MessageAsyncService.class
-                .getDeclaredMethod("saveAsPending", MessageRequest.class);
+                .getDeclaredMethod("saveAsPending", MessageDTO.class);
         method.setAccessible(true);
         ShopMessageHistory result = (ShopMessageHistory) method.invoke(messageAsyncService, testRequest);
 

--- a/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -30,7 +31,7 @@ class MessageIntegrationTest {
 
         // Given - 실제 전송할 메시지
         MessageDTO request = MessageDTO.builder()
-                .to(1)  // 본인 userCode (DB에 실제 존재하는 값)
+                .to(list(1))  // 본인 userCode (DB에 실제 존재하는 값)
                 .from(1)  // shopCode  
                 .sendType("INDIVIDUAL")
                 .subject("개발 테스트")
@@ -70,7 +71,7 @@ class MessageIntegrationTest {
                 "테스트용 긴 메시지입니다. 여러분의 휴대폰으로 잘 도착했나요?";
 
         MessageDTO request = MessageDTO.builder()
-                .to(1)
+                .to(list(1))
                 .from(1)
                 .sendType("INDIVIDUAL")
                 .subject("LMS 테스트")

--- a/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
@@ -57,6 +57,54 @@ class MessageIntegrationTest {
         log.info("💡 DB에서 전송 상태도 확인해보세요 (PENDING → SUCCESS)");
     }
 
+
+
+    @Test
+    //@Disabled("수동 실행 - 실제 단체 SMS 전송됨! 💸💸💸")
+    @DisplayName("단체 SMS 전송 테스트 (배치 처리)")
+    void bulkSmsTest() throws InterruptedException {
+
+        log.info("🚀 단체 SMS 전송 테스트 시작!");
+
+        // Given - 여러 수신자에게 보낼 메시지
+        MessageDTO request = MessageDTO.builder()
+                .to(list(1, 2, 3))  // 여러 userCode (DB에 실제 존재하는 값들로 변경 필요)
+                .from(1)  // shopCode
+                .sendType("GROUP")
+                .subject("단체 발송 테스트")
+                .text("🎉 단체 SMS 테스트입니다! 배치 처리로 전송 중... " + System.currentTimeMillis())
+                .build();
+
+        log.info("📱 수신자 수: {}명", request.getTo().size());
+        log.info("📱 전송할 메시지: {}", request.getText());
+
+        // When - 단체 전송
+        long startTime = System.currentTimeMillis();
+        MessageResponse response = messageAsyncService.sendMessageAsync(request);
+        long responseTime = System.currentTimeMillis() - startTime;
+
+        // Then - 즉시 응답 확인
+        assertThat(response).isNotNull();
+        assertThat(response.getResult()).isEqualTo("PENDING");
+
+        log.info("⚡ PENDING 응답 시간: {}ms", responseTime);
+        log.info("⚡ PENDING 응답 확인 완료: {}", response.getResult());
+        log.info("🔄 백그라운드에서 {}명에게 배치 전송 중...", request.getTo().size());
+
+        // 배치 처리 완료 대기 (수신자 수 * 0.5초 + 여유시간)
+        int waitTime = request.getTo().size() * 500 + 5000;  // 수신자 수에 따라 대기시간 조정
+        log.info("⏰ {}초 대기 중... (수신자 {}명 처리 예상시간)", waitTime / 1000, request.getTo().size());
+
+        Thread.sleep(waitTime);
+
+        log.info("✅ 단체 SMS 테스트 완료!");
+        log.info("📱 모든 수신자의 휴대폰을 확인해보세요!");
+        log.info("💡 DB에서 배치 상태도 확인해보세요:");
+        log.info("   - message_send_batch 테이블: total_count, success_count, fail_count");
+        log.info("   - shop_message_history 테이블: 각 수신자별 send_status (PENDING → SUCCESS/FAIL)");
+        log.info("🎯 배치 처리 성능 확인: 단일 스레드로 순차 처리됨");
+    }
+
     @Test
     @Disabled("수동 실행 - 긴 메시지 LMS 테스트")
     @DisplayName("실제 LMS 전송 테스트")

--- a/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageIntergrationTest.java
@@ -1,6 +1,6 @@
 package com.header.header.domain.message.service;
 
-import com.header.header.domain.message.dto.MessageRequest;
+import com.header.header.domain.message.dto.MessageDTO;
 import com.header.header.domain.message.dto.MessageResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -29,7 +29,7 @@ class MessageIntegrationTest {
         log.info("🚀 실제 SMS 전송 테스트 시작!");
 
         // Given - 실제 전송할 메시지
-        MessageRequest request = MessageRequest.builder()
+        MessageDTO request = MessageDTO.builder()
                 .to(1)  // 본인 userCode (DB에 실제 존재하는 값)
                 .from(1)  // shopCode  
                 .sendType("INDIVIDUAL")
@@ -69,7 +69,7 @@ class MessageIntegrationTest {
                 "현재 시간: " + System.currentTimeMillis() + " " +
                 "테스트용 긴 메시지입니다. 여러분의 휴대폰으로 잘 도착했나요?";
 
-        MessageRequest request = MessageRequest.builder()
+        MessageDTO request = MessageDTO.builder()
                 .to(1)
                 .from(1)
                 .sendType("INDIVIDUAL")

--- a/src/test/java/com/header/header/domain/message/service/MessageSendBatchTests.java
+++ b/src/test/java/com/header/header/domain/message/service/MessageSendBatchTests.java
@@ -93,7 +93,7 @@ public class MessageSendBatchTests {
         Integer updateSuccessCount = 6;
         Integer updateFailCount = 4;
 
-        MessageSendBatchDTO result = messageSendBatchService.updateMessageBatchResults(testBatch.getShopCode(), testBatch.getBatchCode(),updateSuccessCount,updateFailCount);
+        MessageSendBatchDTO result = messageSendBatchService.updateMessageBatchResults(testBatch.getShopCode(), testBatch.getBatchCode(),true);
 
         assertEquals(updateSuccessCount, result.getSuccessCount());
         assertEquals(updateFailCount, result.getFailCount());
@@ -105,7 +105,7 @@ public class MessageSendBatchTests {
         int updateSuccessCount = 6;
         int updateFailCount = 3;
 
-        assertThatThrownBy(() -> messageSendBatchService.updateMessageBatchResults(testBatch.getShopCode(), testBatch.getBatchCode(),updateSuccessCount,updateFailCount))
+        assertThatThrownBy(() -> messageSendBatchService.updateMessageBatchResults(testBatch.getShopCode(), testBatch.getBatchCode(),false))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("일치하지 않는 결과 카운트");
     }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
- 단체 메세지 송신이 가능하도록 코드를 일부 수정하였습니다.
- 메세지 즉시 발송 Facade Service의 메서드를 작성하였습니다.
- 위의 메서드를 이용해 MessageController의 메세지 전송 API를 구현하였습니다.
 
## 🛠리팩토링
- Service에서 사용하던 MessageRequest DTO 명칭을 MessageDTO로 수정하였습니다.
- MessageDTO에서 messageTemplate 필드를 삭제했습니다.
  - FE에서 템플릿을 지정해서 백엔드로 보낼 경우, 템플릿의 매개 변수를 FE쪽에서 채워서 보낼 수 있기 때문에 해당 작업을 Client에 위임함으로써 BE 서버의 부하를 감소시킬 수 있습니다.
- RequestDTO 에서 수신자를 List으로 받으므로써 개별/단체 모두 같은 코드를 사용할 수 있게 수정하였습니다.
- 메세지를 하나만 발송하던 비동기 메서드를 batch 단위로 발송하도록 수정하였습니다. 그 결과 n개의 수신자만큼 생성되던 스레드의 수를 batch당 1개로 감소시켰습니다. 

## 스크린샷 (선택)
postman test 완료하였습니다.
<img width="1324" height="1101" alt="image" src="https://github.com/user-attachments/assets/7b6d812c-4bb5-4599-be45-11fe1f837ed9" />
메세지 발송은 비동기 작업이기때문에 요청 받은 즉시 PENDING 응답을 반환합니다.
이후 메세지 히스토리 조회시 결과를 보실 수 있습니다.

<br>

아래는 실제 DB에 저장된 내용입니다.(파랑색으로 선택된 row 참고하시면 됩니다)
[batchDB]
<img width="1278" height="541" alt="image" src="https://github.com/user-attachments/assets/30af3b95-a6fb-4067-ab54-d505aec82978" />
[historyDB]
<img width="1356" height="542" alt="image" src="https://github.com/user-attachments/assets/298fc357-f659-431b-a4ea-374f7f1c23eb" />


<br>

단체 메세지 발송 테스트 및 API 테스트 문자 결과입니다.
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/ef3925ed-eaf1-43df-b7aa-955486340ba3" />

