### PR TITLE
[HOTFIX] #143 hotfix 수신자 메세지 세부 조회 응답 dto historycode 필드 누락

### DIFF
--- a/src/main/java/com/header/header/domain/message/dto/MessageReceiver.java
+++ b/src/main/java/com/header/header/domain/message/dto/MessageReceiver.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MessageReceiver {
+    private Integer historyCode;
     private String sentAt;
     private String name;
     private String sentStatus;

--- a/src/main/java/com/header/header/domain/message/repository/ShopMessageHistoryRepository.java
+++ b/src/main/java/com/header/header/domain/message/repository/ShopMessageHistoryRepository.java
@@ -24,7 +24,7 @@ public interface ShopMessageHistoryRepository extends JpaRepository<ShopMessageH
             "WHERE h.batchCode = :batchCode")
     List<MessageHistoryListView> findByBatchCode(@Param("batchCode") Integer batchCode);
 
-    Optional<MessageContentView> findByBatchCodeAndUserCode(Integer batchCode, Integer userCode);
+    Optional<MessageContentView> findByBatchCodeAndHistoryCode(Integer batchCode, Integer historyCode);
 
     Optional<ShopMessageHistory> findByHistoryCode(Integer historyCode);
 }

--- a/src/main/java/com/header/header/domain/message/service/MessageHistoryService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageHistoryService.java
@@ -39,15 +39,15 @@ public class MessageHistoryService {
      * 수신자에게 발송한 상세 메세지 내용 조회
      * 복합 INDEX 사용을 위해 batchCode와 함께 조회합니다.
      * @param batchCode 어떤 배치의 수신자 목록을 가져올지
-     * @param userCode 어떤 수신자의 메세지 내용을 가져울지
+     * @param historyCode 어떤 history의 메세지 내용을 가져울지
      * @return List<MessageBatchListView>
      */
-    public MessageContentView getMessageContent(Integer batchCode, Integer userCode){
-        if(batchCode == null || userCode == null){
-            throw new IllegalArgumentException("batchCode,userCode는 필수입니다.");
+    public MessageContentView getMessageContent(Integer batchCode, Integer historyCode){
+        if(batchCode == null || historyCode == null){
+            throw new IllegalArgumentException("batchCode,historyCode 필수입니다.");
         }
 
-        return shopMessageHistoryRepository.findByBatchCodeAndUserCode(batchCode,userCode)
+        return shopMessageHistoryRepository.findByBatchCodeAndHistoryCode(batchCode,historyCode)
                 .orElseThrow(() -> InvalidBatchException.invalidBatchCode("해당 수신자 정보가 없습니다.")); // todo. Exception 수정사항!!
     }
 

--- a/src/main/java/com/header/header/domain/message/service/MessageSendBatchService.java
+++ b/src/main/java/com/header/header/domain/message/service/MessageSendBatchService.java
@@ -38,6 +38,7 @@ public class MessageSendBatchService {
         // 1. 수신자 리스트 조회
         List<MessageReceiver> receiverList = messageHistoryService.getMessageHistoryListByBatch(batchCode).stream()
                 .map( receiver -> MessageReceiver.builder()
+                        .historyCode(receiver.getHistoryCode())
                         .name(receiver.getUserName())
                         .sentStatus(receiver.getSentStatus())
                         .sentAt(receiver.getSentAt() == null ? "-" :receiver.getSentAt().toString())


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [X] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점
- 수신자 메세지 세부 조회 응답 dto에  historycode를 추가하였습니다.
- 
## 💊버그 해결
- historyCode로 메세지 내용을 조회하지 않고 userCode로 조회하던 JPA 메서드를 수정하였습니다.