### PR TITLE
[REFACTOR] #186 샵, 샵 휴일, 유저 예약 도메인 예외 처리 통일

### DIFF
--- a/src/main/java/com/header/header/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/header/header/common/exception/GlobalExceptionHandler.java
@@ -30,23 +30,6 @@ import java.util.Map;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ShopExceptionHandler.class)
-    public ResponseEntity<ResponseMessage> handleShopException(ShopExceptionHandler e) {
-        ShopErrorCode errorInfo = e.getShopErrorCode();
-
-        ErrorResponseMessage error = new ErrorResponseMessage(errorInfo.getCode(), errorInfo.getMessage());
-
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("error", error);
-
-        ResponseMessage responseMessage = new ResponseMessage(400, "잘못된 요청 발생", responseMap);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        return new ResponseEntity<>(responseMessage, headers, HttpStatus.BAD_REQUEST);
-    }
-
     /**
      * NotFoundException 처리
      *

--- a/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
+++ b/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
@@ -37,6 +37,12 @@ import javax.security.auth.login.FailedLoginException;
 @Slf4j
 public class GlobalExeptionHandlerForApiResponse {
 
+    /*
+    * ShopException 처리
+    *
+    * - Shop 도메인의 예외 처리 시 발생
+    * - ShopErrorCode enum에 처리해둔 HttpStatus에 따라 응답
+    * */
     @ExceptionHandler(ShopExceptionHandler.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handleShopExceptionHandler(
             ShopExceptionHandler ex, WebRequest request
@@ -53,6 +59,12 @@ public class GlobalExeptionHandlerForApiResponse {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
     }
 
+    /*
+     * ShopHolidayException 처리
+     *
+     * - Shop 도메인 - Shop Holiday의 예외 처리 시 발생
+     * - ShopHolidayErrorCode enum에 처리해둔 HttpStatus에 따라 응답
+     * */
     @ExceptionHandler(ShopHolidayExceptionHandler.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handleShopHolidayExceptionHandler(
             ShopHolidayExceptionHandler ex, WebRequest request
@@ -69,8 +81,12 @@ public class GlobalExeptionHandlerForApiResponse {
         return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
     }
 
-    // TODO. Exception Class 주석 추가
-
+    /*
+     * UserReservationException 처리
+     *
+     * - UserReservation 도메인의 예외 처리 시 발생
+     * - UserReservationErrorCode enum에 처리해둔 HttpStatus에 따라 응답
+     * */
     @ExceptionHandler(UserReservationExceptionHandler.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handleUserReservationExceptionHandler(
             UserReservationExceptionHandler ex, WebRequest request

--- a/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
+++ b/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
@@ -5,6 +5,7 @@ import com.header.header.auth.exception.DuplicatedUserIdException;
 import com.header.header.auth.exception.RegistrationUnknownException;
 import com.header.header.common.dto.ResponseDTO;
 import com.header.header.common.dto.response.ApiResponse;
+import com.header.header.domain.shop.exception.ShopExceptionHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,10 +25,27 @@ import javax.security.auth.login.FailedLoginException;
 @RestControllerAdvice(basePackages = {
         "com.header.header.domain.visitors",
         "com.header.header.domain.message",
-        "com.header.header.domain.user"
+        "com.header.header.domain.user",
+        "com.header.header.domain.shop"
 })
 @Slf4j
 public class GlobalExeptionHandlerForApiResponse {
+
+    @ExceptionHandler(ShopExceptionHandler.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleShopExceptionHandler(
+            ShopExceptionHandler ex, WebRequest request
+    ){
+        log.error("ShopException 발생: {} - {} ", ex.getShopErrorCode(), ex.getMessage(), ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ex.getShopErrorCode().ordinal(),
+                String.valueOf(ex.getShopErrorCode()),
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+
+        return ResponseEntity.status(ex.getShopErrorCode().ordinal()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
+    }
 
     /**
      * NotFoundException 처리

--- a/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
+++ b/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
@@ -5,8 +5,12 @@ import com.header.header.auth.exception.DuplicatedUserIdException;
 import com.header.header.auth.exception.RegistrationUnknownException;
 import com.header.header.common.dto.ResponseDTO;
 import com.header.header.common.dto.response.ApiResponse;
+import com.header.header.domain.reservation.enums.UserReservationErrorCode;
 import com.header.header.domain.reservation.exception.UserReservationExceptionHandler;
+import com.header.header.domain.shop.enums.ShopErrorCode;
+import com.header.header.domain.shop.enums.ShopHolidayErrorCode;
 import com.header.header.domain.shop.exception.ShopExceptionHandler;
+import com.header.header.domain.shop.exception.ShopHolidayExceptionHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,31 +42,49 @@ public class GlobalExeptionHandlerForApiResponse {
             ShopExceptionHandler ex, WebRequest request
     ){
         log.error("ShopException 발생: {} - {} ", ex.getShopErrorCode(), ex.getMessage(), ex);
-
+        ShopErrorCode errorCode = ex.getShopErrorCode();
         ErrorResponse errorResponse = ErrorResponse.of(
-                ex.getShopErrorCode().ordinal(),
-                String.valueOf(ex.getShopErrorCode()),
+                errorCode.getHttpStatus().value(),
+                String.valueOf(errorCode.getCode()),
                 ex.getMessage(),
                 request.getDescription(false).replace("uri=", "")
         );
 
-        return ResponseEntity.status(ex.getShopErrorCode().ordinal()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
     }
+
+    @ExceptionHandler(ShopHolidayExceptionHandler.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleShopHolidayExceptionHandler(
+            ShopHolidayExceptionHandler ex, WebRequest request
+    ){
+        log.error("ShopHolidayException 발생: {} - {} ", ex.getShopHolidayErrorCode(), ex.getMessage(), ex);
+        ShopHolidayErrorCode errorCode = ex.getShopHolidayErrorCode();
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                errorCode.getHttpStatus().value(),
+                String.valueOf(errorCode.getCode()),
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
+    }
+
+    // TODO. Exception Class 주석 추가
 
     @ExceptionHandler(UserReservationExceptionHandler.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handleUserReservationExceptionHandler(
             UserReservationExceptionHandler ex, WebRequest request
     ){
         log.error("UserReservationException 발생: {} - {} ", ex.getURErrorCode(), ex.getMessage(), ex);
-
+        UserReservationErrorCode errorCode = ex.getURErrorCode();
         ErrorResponse errorResponse = ErrorResponse.of(
-                ex.getURErrorCode().ordinal(),
-                String.valueOf(ex.getURErrorCode()),
+                errorCode.getHttpStatus().value(),
+                String.valueOf(errorCode.getCode()),
                 ex.getMessage(),
                 request.getDescription(false).replace("uri=", "")
         );
 
-        return ResponseEntity.status(ex.getURErrorCode().ordinal()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
     }
 
     /**

--- a/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
+++ b/src/main/java/com/header/header/common/exception/GlobalExeptionHandlerForApiResponse.java
@@ -5,6 +5,7 @@ import com.header.header.auth.exception.DuplicatedUserIdException;
 import com.header.header.auth.exception.RegistrationUnknownException;
 import com.header.header.common.dto.ResponseDTO;
 import com.header.header.common.dto.response.ApiResponse;
+import com.header.header.domain.reservation.exception.UserReservationExceptionHandler;
 import com.header.header.domain.shop.exception.ShopExceptionHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,7 +27,8 @@ import javax.security.auth.login.FailedLoginException;
         "com.header.header.domain.visitors",
         "com.header.header.domain.message",
         "com.header.header.domain.user",
-        "com.header.header.domain.shop"
+        "com.header.header.domain.shop",
+        "com.header.header.domain.reservation"
 })
 @Slf4j
 public class GlobalExeptionHandlerForApiResponse {
@@ -45,6 +47,22 @@ public class GlobalExeptionHandlerForApiResponse {
         );
 
         return ResponseEntity.status(ex.getShopErrorCode().ordinal()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
+    }
+
+    @ExceptionHandler(UserReservationExceptionHandler.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleUserReservationExceptionHandler(
+            UserReservationExceptionHandler ex, WebRequest request
+    ){
+        log.error("UserReservationException 발생: {} - {} ", ex.getURErrorCode(), ex.getMessage(), ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ex.getURErrorCode().ordinal(),
+                String.valueOf(ex.getURErrorCode()),
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+
+        return ResponseEntity.status(ex.getURErrorCode().ordinal()).body(ApiResponse.fail(ex.getMessage(), errorResponse));
     }
 
     /**

--- a/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
+++ b/src/main/java/com/header/header/domain/reservation/enums/UserReservationErrorCode.java
@@ -2,25 +2,27 @@ package com.header.header.domain.reservation.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum UserReservationErrorCode {
 
-    UNKNOWN_DB_VALUE("UNKNOWN_DB_VALUE", "유효하지 않은 값입니다."),
-    RESV_NOT_FOUND("RESV_NOT_FOUND", "예약 정보를 찾을 수 없습니다."),
-    RESV_ALREADY_DEACTIVATED("RESV_ALREADY_DEACTIVATED", "이미 취소된 예약입니다."),
-    RESV_ALREADY_FINISHED("RESV_ALREADY_FINISHED", "이미 완료된 예약은 취소할 수 없습니다."),
-    RESV_ALREADY_PAID("RESV_ALREADY_PAID", "결제 완료된 예약은 취소할 수 없습니다."),
-    USER_NOT_FOUND("USER_NOT_FOUND", "유효하지 않은 사용자 정보입니다."),
-    USER_HAS_LEFT("USER_HAS_LEFT", "탈퇴한 사용자 정보입니다"),
-    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "조회 시작 날짜는 조회 종료 날짜보다 이전이어야 합니다."),
-    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "샵 정보를 찾을 수 없습니다."),
-    MENU_NOT_FOUND("MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다."),
-    DATE_HAS_HOL("DATE_HAS_HOL", "선택하신 날짜는 샵 휴무일 입니다."),
-    SCHEDULE_ALREADY_TAKEN("SCHEDULE_ALREADY_TAKEN", "해당 시간은 이미 예약되었습니다. \n 다른 일정을 선택해 주세요."),
-    USER_SCHEDULE_UNAVAILABLE("USER_SCHEDULE_UNAVAILABLE", "해당 일정에 고객님의 다른 시술이 예정되어 있습니다. \n 다른 일정을 선택해 주세요.");
+    UNKNOWN_DB_VALUE("UNKNOWN_DB_VALUE", "유효하지 않은 값입니다.", HttpStatus.BAD_REQUEST),
+    RESV_NOT_FOUND("RESV_NOT_FOUND", "예약 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RESV_ALREADY_DEACTIVATED("RESV_ALREADY_DEACTIVATED", "이미 취소된 예약입니다.", HttpStatus.CONFLICT),
+    RESV_ALREADY_FINISHED("RESV_ALREADY_FINISHED", "이미 완료된 예약은 취소할 수 없습니다.", HttpStatus.CONFLICT),
+    RESV_ALREADY_PAID("RESV_ALREADY_PAID", "결제 완료된 예약은 취소할 수 없습니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("USER_NOT_FOUND", "유효하지 않은 사용자 정보입니다.", HttpStatus.NOT_FOUND),
+    USER_HAS_LEFT("USER_HAS_LEFT", "탈퇴한 사용자 정보입니다", HttpStatus.GONE),
+    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "조회 시작 날짜는 조회 종료 날짜보다 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "샵 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MENU_NOT_FOUND("MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DATE_HAS_HOL("DATE_HAS_HOL", "선택하신 날짜는 샵 휴무일 입니다.", HttpStatus.BAD_REQUEST),
+    SCHEDULE_ALREADY_TAKEN("SCHEDULE_ALREADY_TAKEN", "해당 시간은 이미 예약되었습니다.\n다른 일정을 선택해 주세요.", HttpStatus.CONFLICT),
+    USER_SCHEDULE_UNAVAILABLE("USER_SCHEDULE_UNAVAILABLE", "해당 일정에 고객님의 다른 시술이 예정되어 있습니다.\n다른 일정을 선택해 주세요.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/header/header/domain/shop/enums/ShopErrorCode.java
+++ b/src/main/java/com/header/header/domain/shop/enums/ShopErrorCode.java
@@ -2,6 +2,7 @@ package com.header.header.domain.shop.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -9,16 +10,17 @@ public enum ShopErrorCode {
 
     // Shop CRUD 시 발생할 수 있는 에러 코드를 관리하는 enum
 
-    NOT_SUPPORTED_REQUEST("NOT_SUPPORTED_REQUEST", "유효하지 않은 접근입니다."),
-    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "해당 샵을 찾을 수 없습니다."),
-    SHOP_DEACTIVATED("SHOP_DEACTIVATED", "해당 샵은 비활성화 되었습니다."),
-    SHOP_ALREADY_DEACTIVATED("SHOP_ALREADY_DEACTIVATED", "해당 샵은 이미 비활성화 상태입니다."),
-    LOCATION_NOT_FOUND("LOCATION_NOT_FOUND", "잘못된 주소입니다."),
-    UNKNOWN_DB_VALUE("UNKNOWN_DB_VALUE", "유효하지 않은 값입니다."),
-    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다."),
-    SHOP_CATEGORY_NOT_FOUND("SHOP_CATEGORY_NOT_FOUND", "유효하지 않은 카테고리 입니다."),
-    SHOP_IS_EMPTY("SHOP_IS_EMPTY", "보유한 샵이 존재하지 않습니다.");
+    NOT_SUPPORTED_REQUEST("NOT_SUPPORTED_REQUEST", "유효하지 않은 접근입니다.", HttpStatus.BAD_REQUEST),
+    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "해당 샵을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SHOP_DEACTIVATED("SHOP_DEACTIVATED", "해당 샵은 비활성화 되었습니다.", HttpStatus.GONE),
+    SHOP_ALREADY_DEACTIVATED("SHOP_ALREADY_DEACTIVATED", "해당 샵은 이미 비활성화 상태입니다.", HttpStatus.CONFLICT),
+    LOCATION_NOT_FOUND("LOCATION_NOT_FOUND", "잘못된 주소입니다.", HttpStatus.NOT_FOUND),
+    UNKNOWN_DB_VALUE("UNKNOWN_DB_VALUE", "유효하지 않은 값입니다.", HttpStatus.BAD_REQUEST),
+    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다.", HttpStatus.NOT_FOUND),
+    SHOP_CATEGORY_NOT_FOUND("SHOP_CATEGORY_NOT_FOUND", "유효하지 않은 카테고리 입니다.", HttpStatus.NOT_FOUND),
+    SHOP_IS_EMPTY("SHOP_IS_EMPTY", "보유한 샵이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/header/header/domain/shop/enums/ShopHolidayErrorCode.java
+++ b/src/main/java/com/header/header/domain/shop/enums/ShopHolidayErrorCode.java
@@ -2,18 +2,20 @@ package com.header.header.domain.shop.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum ShopHolidayErrorCode {
 
-    DATE_UNAVAILABLE("DATE_UNAVAILABLE", "해당 날짜는 예약이 불가능합니다."),
-    DATE_HAS_RESV("DATE_HAS_RESV", "해당 날짜에는 예약이 존재합니다. 예약을 취소한 후 다시 시도하세요."),
-    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "휴일 시작 날짜는 휴일 종료 날짜보다 앞이어야 합니다."),
-    HOL_NOT_FOUND("HOL_NOT_FOUND", "수정할 휴일 정보를 찾을 수 없습니다."),
-    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "유효하지 않은 샵 정보입니다."),
-    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다.");
+    DATE_UNAVAILABLE("DATE_UNAVAILABLE", "해당 날짜는 예약이 불가능합니다.", HttpStatus.CONFLICT),
+    DATE_HAS_RESV("DATE_HAS_RESV", "해당 날짜에는 예약이 존재합니다. 예약을 취소한 후 다시 시도하세요.", HttpStatus.CONFLICT),
+    INPUT_DATE_WRONG("INPUT_DATE_WRONG", "휴일 시작 날짜는 휴일 종료 날짜보다 앞이어야 합니다.", HttpStatus.BAD_REQUEST),
+    HOL_NOT_FOUND("HOL_NOT_FOUND", "수정할 휴일 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SHOP_NOT_FOUND("SHOP_NOT_FOUND", "유효하지 않은 샵 정보입니다.", HttpStatus.NOT_FOUND),
+    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "유효하지 않은 관리자 정보입니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

- `GlobalExceptionHandlerForApiResponse` 수정
     - `샵`, `샵 휴일`, `유저 예약` 도메인 예외처리 추가
     - `예외 처리 방식` 통일

 
## 🛠리팩토링

- ShopExceptionHandler (menu, sales 예외 처리용) 의 ShopException 예외 처리 코드 삭제
- ErrorCode를 관리하는 각 도메인의 enum에 HttpStatus 추가     
  -> 서버 에러 응답시 개발자가 의도한 상태 코드로 응답 

## 스크린샷 (선택)

- **글로벌 예외처리기 동작 확인**
    - 샵 생성시 주소 입력 안 함
    - `500` 에러
<img width="843" height="621" alt=" 샵 생성 예외 - 주소 입력 (500)" src="https://github.com/user-attachments/assets/f2254764-ef38-4a42-8ff7-03e668744d6d" />

- **샵 예외 처리**
    - 비활성화된 샵 재비활성화 시도
    - `409` 에러
<img width="844" height="547" alt="샵 비활성화 예외 - 재비활성화 409" src="https://github.com/user-attachments/assets/47a58254-76d7-4e62-8fab-7d055633a88a" />

- **샵 휴일 예외 처리**
    - 다른 관리자의 샵 정보 입력
    - `404` 에러
<img width="852" height="540" alt="샵 휴일 예외 - 본인 것이 아닌 샵 코드 입력" src="https://github.com/user-attachments/assets/a0ef833f-2e89-4f8b-aa23-6d8be3fba675" />

- **고객 샵 검색 예외 처리**
    - 존재하지 않는 카테고리 입력
    - `404` 에러
<img width="843" height="567" alt="샵 검색 예외 - 잘못된 카테고리 필터 적용" src="https://github.com/user-attachments/assets/7ce67366-83be-42d4-a0e8-bece9186ba8b" />

closed #186 

 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 샵/휴무/예약 도메인에 대한 전역 예외 처리 추가. 오류를 일관된 ApiResponse 형식(HTTP 상태, 에러 코드, 메시지, 요청 경로)으로 반환해 응답 해석이 쉬워졌습니다.

* Refactor
  * 도메인 오류에 적절한 HTTP 상태코드 매핑(BAD_REQUEST, NOT_FOUND, CONFLICT, GONE) 적용으로 응답 정확성과 클라이언트 사이드 처리 용이성 향상.
  * 예외 처리 범위를 해당 도메인으로 확장해 교차 도메인 오류도 중앙에서 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->