### PR TITLE
[FIX] #194 Modify Docker Compose File

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,17 +84,17 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:rw
-
     healthcheck:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-p$MYSQL_ROOT_PASSWORD" ]
       interval: 5s
       timeout: 3s
       retries: 5
-
     # command 설정을 통해 한글/이모지 깨짐 방지 가능
     command:
       - --character-set-server=utf8mb4  # MySQL 서버 기본 문자셋을 UTF-8로 설정
       - --collation-server=utf8mb4_unicode_ci  # 정렬 기준 설정
+    networks:
+      - webnet
 
 volumes:
   mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - mysql-data:/var/lib/mysql
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:rw
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-p$MYSQL_ROOT_PASSWORD" ]
+      test: [ "CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -p$$MYSQL_ROOT_PASSWORD" ]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 버그 수정 <br>
 
## 💊버그 해결

Docker 내에서 여러 컨테이너들끼리 같은 네트워크(webnet)에 있어야만 headerdb라는 서비스명을 호스트명으로 사용할 수 있기에 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - headerdb 서비스를 기존 webnet 네트워크에 연결하도록 구성했습니다.
  - headerdb의 상태 확인(헬스체크) 방식이 안정성 향상을 위해 조정되었습니다(대상 및 실행 방식 변경).
  - 볼륨과 명령 등 다른 실행 구성은 변경되지 않았습니다.
  - 영향: 서비스 간 네트워크 연결 일관성 및 배포 환경의 구성 신뢰성이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->