### PR TITLE
[Fix] #200 Modify Dockerfile And Deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,4 +114,4 @@ jobs:
 
             docker pull ${{ secrets.DOCKER_USERNAME }}/header-back-img:master
             docker compose -f docker-compose.yml down -v || true
-            docker compose -f docker-compose.yml up -d --build
+            docker compose -f docker-compose.yml up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,5 +113,5 @@ jobs:
             git pull origin master
 
             docker pull ${{ secrets.DOCKER_USERNAME }}/header-back-img:master
-            docker compose -f docker-compose.yml down -v || true
+            docker compose -f docker-compose.yml down || true
             docker compose -f docker-compose.yml up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,8 @@ WORKDIR /app
 # 애플리케이션 JAR 복사
 COPY --from=build /app/build/libs/*.jar app.jar
 
-# application.yml을 명시적으로 복사
-COPY src/main/resources/application.yml /app/config/application.yml
-
 # 포트 노출
 EXPOSE 8080
 
 # Spring Boot가 해당 경로를 읽도록 지정
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.location=file:/app/config/application.yml"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 버그 수정 <br>
 
## 💊버그 해결

현재 문제 : 
CI 과정에서 만든 application.yml 파일(Github Actions Secretes로 관리)을 CD 과정에서 사용하지 않고 로컬 소스로 다시 재빌드하여 사용함. 
하지만 로컬 소스에는 application.yml이 .gitignore 되어서 파일이 없음.
그 결과 배포되는 컨테이너에 application.yml 파일이 없는데 Dockerfile에서는 해당 파일을 복사하려니까 오류가 떠서 배포가 중단 됨
                     
해결 방안 : 
CI 과정에서 만든 application.yml 파일도 함께 빌드된 도커 이미지를 그대로 CD에서 pull 받아서 사용하도록 수정
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * 배포 파이프라인에서 볼륨 삭제 옵션(-v)과 자동 이미지 재빌드(--build)를 제거해 기존 볼륨을 보존하고 배포 시간을 단축했습니다. 배포는 기존 이미지 기반으로 시작됩니다.
  * 컨테이너 시작 절차에서 외부 설정 파일 참조를 제거하고 기본 내장 설정을 사용하도록 단순화해 운영 안정성과 설정 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->