### PR TITLE
[FIX] #208 Modify Docker Service Name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
       - develope
 
 jobs:
-  header_backend:
+  header-backend:
     runs-on: ubuntu-latest
 
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # 여기선 하나의 서비스인 header-backend-server만 정의한다.
 services:
   # 서비스 이름, 나중에 docker compose up 명령으로 이 이름을 기준으로 컨테이너가 실행됨
-  header_backend:
+  header-backend:
     # 이 섹션은 Docker 이미지를 직접 빌드할 것임을 나타낸다.
     build:
       # context : . -> 현재 디렉토리를 빌드 컨텍스트로 사용하겠다는 의미.
@@ -13,7 +13,7 @@ services:
       dockerfile: Dockerfile
       # 컨테이너 이름 수동으로 설정
       # 지정하지 않으면 프로젝트이름_서비스이름_번호 형식으로 자동 생성
-    container_name: header_backend
+    container_name: header-backend
     # environment란
     # Spring Boot의 application.properties/application.yml 설정을 외부에서 주입할 수 있게 해준다.
     # 즉 Spring Boot에서 이 값들을 자동으로 읽는다.
@@ -52,7 +52,7 @@ services:
       - "80:80"
       - "443:443"
     depends_on:
-      - header_backend
+      - header-backend
     networks:
       - webnet
 

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -25,8 +25,8 @@ server {
     ssl_ciphers HIGH:!aNULL:!MD5;
 
     location / {
-        proxy_pass http://header_backend:8080;
-        proxy_set_header Host $host;
+        proxy_pass http://header-backend:8080;
+        proxy_set_header Host api.headercrm.site;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 버그 수정 <br>
 
## 💊버그 해결

NGINX 설정에서 Host 헤더가 header_backend로 설정됨
Tomcat은 HTTP 표준에 따라 _가 포함된 도메인을 거부함
 👉 400 Bad Request 발생

🔍 왜 이런 일이 생길까?
Tomcat은 요청을 받을 때 Host 헤더를 파싱해서 유효한 도메인인지 검사한다. 하지만 RFC 규격에 따르면 도메인 이름에는 _가 들어갈 수 없다. 그래서 Tomcat은 400에러를 발생함

