### PR TITLE
[HOTFIX] #231 hotfix securityconfig fix

### DIFF
--- a/src/main/java/com/header/header/auth/config/SecurityConfig.java
+++ b/src/main/java/com/header/header/auth/config/SecurityConfig.java
@@ -78,8 +78,7 @@ public class SecurityConfig {
                 // 요청에 대한 권한 설정
                 .authorizeHttpRequests(auth -> {
                     // 다음 경로들은 인증 없이 모든 사용자에게 허용
-                    //auth.requestMatchers("/auth/**", "/", "/main").permitAll();
-                    auth.requestMatchers("/", "/main").permitAll();
+                    auth.requestMatchers("/auth/**", "/", "/main").permitAll();
                     // "/auth/session" (POST) 요청을 허용하여 로그인 시도를 가능하게 합니다.
                     auth.requestMatchers(HttpMethod.POST, "/auth/session").permitAll();
                     // "auth/password-reset"(POST) 요청도 허용하여 비 로그인 상태에서의 비밀번호 변경활동을 가능하게 합니다.


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 버그 수정

## 👍변경점

"/auth/users" 회원가입 불가 해결 위해 SecurityConfig permitall 수정
 
## 💊버그 해결

"/auth/users" 회원가입 불가 해결 위해 SecurityConfig permitall 수정

## 스크린샷 (선택)

<img width="604" height="68" alt="image" src="https://github.com/user-attachments/assets/bb3e8c2f-4879-4b3f-b9db-211540a4b620" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 인증 관련 엔드포인트의 접근성이 향상되었습니다.
  - /auth/** 경로가 공개되어 로그인 없이 필요한 인증 작업을 진행할 수 있습니다.
  - 비밀번호 재설정(POST /auth/password-reset)과 세션 생성(POST /auth/session)을 로그인 없이 요청할 수 있습니다.
  - 기존의 다른 접근 제한 규칙은 그대로 유지되어 보안 정책과 사용성의 균형을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->