### PR TITLE
[FEATURE] #296 Add WebMvcConfig

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -31,5 +31,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        charset utf-8;
     }
 }

--- a/src/main/java/com/header/header/config/WebMvcConfig.java
+++ b/src/main/java/com/header/header/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.header.header.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>>  converters) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setDefaultCharset(StandardCharsets.UTF_8);
+        converters.add(converter);
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 기능 추가 <br>


## 👍변경점

한글 깨지는 원인
 : Response Header에서 charset 누락

해결방안
Content-Type: application/json;charset=UTF-8 이 명확하게 내려가서 브라우저가 더 이상 ISO-8859-1로 오해하지 않도록 WebMvcConfig 파일 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일부 페이지와 API 응답에서 발생하던 문자 인코딩 문제를 해결하여 한글 등 멀티바이트 문자가 깨지지 않고 정상적으로 표시됩니다.
* **Chores**
  * 서버 전역의 HTTP 응답과 JSON 직렬화 기본 인코딩을 UTF-8로 통일하여 콘텐츠 표시 일관성과 국제화 호환성을 개선했습니다. 프록시를 거치는 응답도 동일한 인코딩이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->