### PR TITLE
[FIX] #302 Edit Redis Config - Redis 연결 환경 설정 개선 및 Docker 환경 대응

### DIFF
--- a/llm/app/core/config.py
+++ b/llm/app/core/config.py
@@ -27,10 +27,14 @@ class ChatBotConfig:
 
         return value
 
+def is_docker() -> bool:
+    """ docker 환경인지 감지 """
+    return bool(os.getenv("HOSTNAME") or os.path.exists("/.dockerenv"))
+
 def detect_env_file():
     """환경에 따라 적절한 .env 파일을 선택"""
     import os
-    
+
     # Docker 환경 감지 (HOSTNAME 환경변수 또는 컨테이너 특정 조건)
     if os.getenv("HOSTNAME") or os.path.exists("/.dockerenv"):
         return "../.env"
@@ -45,7 +49,8 @@ class Settings(BaseSettings):
     spring_api_base_url: str = Field(default="http://127.0.0.1:8080")
 
     # Redis 설정
-    redis_url: str = Field(default="redis://localhost:6379")
+    # redis_url: str = Field(default="redis://localhost:6379")
+    redis_url: str = Field(default=f"redis://{'header-redis' if is_docker() else 'localhost'}:6379")
     redis_stream_data_requests: str = Field(default="data-requests")
     redis_stream_data_results: str = Field(default="data-results")
     redis_consumer_group: str = Field(default="fastapi-consumers")


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 버그 수정 <br>

## 💊버그 해결

1. **Redis 연결 URL 환경별 분기 처리**
   - 로컬: `redis://localhost:6379`
   - Docker 환경: `redis://header-redis:6379`
   - 배포 시 LLM 컨테이너가 Redis에 정상적으로 연결 가능하도록 개선

2. **Docker 환경 감지 함수 추가**
   - `is_docker()` 함수 도입
   - `HOSTNAME` 환경변수 또는 `/.dockerenv` 존재 여부로 Docker 환경 감지

3. **Settings 클래스 수정**
   - Redis URL 기본값을 `is_docker()` 결과에 따라 동적으로 설정
   - 기존에는 항상 `localhost` 사용 → Docker 환경에서 Redis 연결 실패 문제 발생

4. **기타 개선 사항**
   - 불필요한 주석 정리
   - `detect_env_file()` 함수 재사용하여 `.env` 파일 선택 유지

## 기대 효과

- 로컬 개발 환경과 Docker 배포 환경 모두에서 Redis 연결 문제 해결
- LLM 컨테이너 시작 시 발생하던
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 실행 환경(Docker 여부)을 자동 감지하여 기본 설정을 환경에 맞게 적용합니다.
  - Docker 실행 시 상위 경로의 .env 파일을, 로컬 실행 시 .env.local을 사용합니다.
  - Redis 기본 연결 주소가 환경 인식으로 변경되어 Docker에서는 컨테이너 호스트를, 로컬에서는 localhost를 자동 사용합니다.
  - 결과적으로 초기 설정이 간소화되고, 로컬 개발과 컨테이너 환경 간의 동작 일관성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->