### PR TITLE
[FIX] #314 Edit WebMvcConfig File - Spring Boot 한글 깨짐 문제

### DIFF
--- a/src/main/java/com/header/header/config/WebMvcConfig.java
+++ b/src/main/java/com/header/header/config/WebMvcConfig.java
@@ -18,6 +18,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         converter.setDefaultCharset(StandardCharsets.UTF_8);converter.setSupportedMediaTypes(List.of(
                 new MediaType("application", "json", StandardCharsets.UTF_8)
         ));
+        converters.clear();
         converters.add(converter);
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 버그 수정 <br>

## 💊버그 해결

### 문제 상황
Spring Boot 컨트롤러에서 JSON 응답을 반환할 때, 한글이 깨지는 문제가 발생함.

- **Content-Type 헤더**는 `application/json;charset=UTF-8`로 올바르게 설정됨.
- 그러나 실제 응답 본문(body)은 ISO-8859-1로 인코딩되어 전송되어 클라이언트에서 한글이 깨짐.

### 원인 분석
Spring Boot의 응답 처리 과정은 크게 두 단계로 나뉨:

1. **컨텐츠 협상 (Content Negotiation) 및 헤더 설정**  
   - 컨트롤러가 객체(Object)를 반환하면 Spring이 Accept 헤더 등을 보고 MediaType 결정
   - `WebMvcConfig`에서 설정한 `MediaType("application", "json", StandardCharsets.UTF_8)` 정보 사용
   - 결과: `Content-Type` 헤더는 `application/json;charset=UTF-8`로 설정

2. **메시지 변환 (Message Conversion)**  
   - 헤더 설정 후, 실제 객체를 JSON 문자열(byte array)로 변환
   - `HttpMessageConverter` 목록을 순서대로 탐색
   - 문제 발생:  
     - `MappingJackson2HttpMessageConverter`(UTF-8)보다 앞서 기본 `StringHttpMessageConverter`가 사용될 수 있음
     - 기본 `StringHttpMessageConverter`의 디폴트 인코딩은 ISO-8859-1
     - 따라서 응답 본문은 잘못된 인코딩으로 전송됨

## 해결 방법
- WebMvcConfig에서 메시지 컨버터 순서를 조정하여 UTF-8을 우선 적용

```java
@Override
public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
    MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
    converter.setDefaultCharset(StandardCharsets.UTF_8);

    // 기존 컨버터보다 우선순위 높게 설정
    converters.add(0, converter);

    // 또는
    // converters.clear();
    // converters.add(converter);
}