### PR TITLE
[FIX] #317 Edit Init.sql File

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,3 +1,5 @@
+SET NAMES utf8mb4;
+
 create database if not exists `headerdb`;
 grant all privileges on headerdb.* to 'ohgiraffers'@'%';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     # ./init.sql:/docker-entrypoint-initdb.d/init.sql : 컨테이너 시작 시 init.sql을 자동 실행(테이블 생성 등 초기화 작업 가능)
     volumes:
       - mysql-data:/var/lib/mysql
-      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:rw
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: [ "CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -p$$MYSQL_ROOT_PASSWORD" ]
       interval: 20s


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 버그 수정 <br>
 
## 💊버그 해결

### 1. 문제 원인

- MySQL 서버는 `character-set-server=utf8mb4`로 설정되어 있어 **서버 기본값은 UTF-8**로 동작.
- 그러나 **클라이언트 연결 문자셋**(`character_set_client`, `character_set_connection`, `character_set_results`)이 latin1 등 다른 문자셋으로 잡히면 문제가 발생.
- Docker 컨테이너 내에서 `docker-entrypoint-initdb.d/init.sql`이 실행될 때, MySQL 클라이언트 문자셋이 latin1일 수 있음.
- UTF-8로 작성된 SQL 파일을 이 상태에서 실행하면:
  - MySQL은 SQL을 **latin1로 해석**
  - UTF-8 컬럼에 저장 → **바이트 값 깨짐**
  - 결과적으로 SELECT 시 HEX 값이 이상하게 나타나고 한글이 깨짐

### 2. 해결 방법

- `init.sql` 맨 위에 다음 구문 추가:

```sql
SET NAMES utf8mb4;



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 환경변수(SPRING_REDIS_HOST/SPRING_REDIS_PORT)로 Redis 접속 설정을 지원합니다.
* 버그 수정
  * 데이터베이스 초기화 시 utf8mb4 인코딩을 강제해 이모지/다국어 문자 깨짐 문제를 방지했습니다.
  * HTTP 메시지 컨버터를 초기화 후 JSON(UTF-8) 응답으로 일관되게 처리하도록 조정했습니다.
* 기타 작업
  * Docker 초기화 SQL을 컨테이너 내 읽기 전용으로 마운트해 안정성과 안전성을 개선했습니다.
  * 구성 로직을 정리하여 환경파일 감지와 설정 기본값 처리를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->