### PR TITLE
[FIX] #320 clarify json format in available time method

### DIFF
--- a/src/main/java/com/header/header/domain/reservation/dto/ReservationDateAndTimeDTO.java
+++ b/src/main/java/com/header/header/domain/reservation/dto/ReservationDateAndTimeDTO.java
@@ -1,5 +1,6 @@
 package com.header.header.domain.reservation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,8 +15,14 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 public class ReservationDateAndTimeDTO {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate targetDate;
+
+    @JsonFormat(pattern = "HH:mm:ss")
     private List<LocalTime> availableTimes;
+
+    @JsonFormat(pattern = "HH:mm:ss")
     private List<LocalTime> reservedTimes;
 
     public ReservationDateAndTimeDTO(LocalDate targetDate, List<LocalTime> availableTimes, List<LocalTime> reservedTimes){

--- a/src/main/java/com/header/header/domain/reservation/dto/UserResvAvailableScheduleDTO.java
+++ b/src/main/java/com/header/header/domain/reservation/dto/UserResvAvailableScheduleDTO.java
@@ -1,5 +1,6 @@
 package com.header.header.domain.reservation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -19,8 +20,10 @@ public class UserResvAvailableScheduleDTO {
 
     /* 날짜만 다뤄야 하기 때문에, 혹시 모를 문제점을 방지하기 위해 LocalDate 사용
     *  + LocalDate는 불변 객체로 스레드 안전성을 보장한다 */
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate targetDate;
 
     // 현재 시간대 정보 필요해서 LocalTime 사용
+    @JsonFormat(pattern = "HH:mm:ss")
     private List<LocalTime> availableTimes;
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [x] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 
## 💊버그 해결

- 예약 가능 시간 반환에서 포맷이 "YYYY-mm-DD" 가 아닌 YYYY, MM, DD 로 오는 오류
     - 관련 dto에 JSON 형식 명시하여 해결
 
